### PR TITLE
docs: resumir guia de arquitectura

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,9 +1,17 @@
 # Arquitectura — SmartEdify_V0
 
+## Resumen de la guía de arquitectura
+- Principios rectores: un servicio por responsabilidad, contratos primero (OpenAPI y esquemas de eventos), compatibilidad hacia atrás, seguridad *least privilege* y observabilidad integral.
+- Correcciones clave acordadas con el CTO: rotación operativa de JWKS, mensajería en NATS con *subjects* versionados y DLQ por servicio, pipeline CI con *gates* (lint, pruebas, cobertura ≥80 %, SBOM, SAST, escaneo de contenedores) y hardening (contenedores no root, FS inmutable, límites de recursos, CORS estricto).
+- Diseño de servicios: gateway BFF, auth, tenant, assembly, reservation, maintenance y módulos lite para documentos, comunicaciones, finanzas y pagos.
+- Prácticas operativas: versionado `/v1` en HTTP y `v1.<dominio>.<evento>` en eventos, idempotencia con `409` + `idempotency-key` y `event_id`, migraciones *forward-only* con planes de rollback y retenciones definidas (outbox 7 días, DLQ 30 días, documentos WORM).
+- Observabilidad y seguridad: export OTLP con `trace_id` en logs, dashboards para latencia/error/*consumer lag*, JWT con *claims* obligatorias, TLS de extremo a extremo, HSTS y gestión de secretos en GitHub Secrets + AWS Secrets Manager.
+- Documentación viva: `docs/README.md#documento-rector--smartedify_v0` y este archivo se actualizan mediante PR.
+
+Consulta la guía completa en [docs/architecture/guidelines.md](docs/architecture/guidelines.md).
+
 ## Visión
 Plataforma SaaS con dominios: User Portal, Admin Portal, Mobile App. Servicios base: auth, user, tenant. Integración asincrónica con outbox y broker. Seguridad por defecto.
-Resumen guía consolidada: servicios independientes, contratos versionados, seguridad *least privilege*, observabilidad end-to-end y CI/CD con gates estrictos.
-Detalles ampliados en [docs/architecture/guidelines.md](docs/architecture/guidelines.md).
 
 ## Contexto (C4 nivel 1)
 - Usuarios finales → User Portal y Mobile.


### PR DESCRIPTION
## Summary
- agrega un resumen conciso de docs/architecture/guidelines.md al inicio de ARCHITECTURE.md
- enlaza directamente con la guía detallada para facilitar la navegación

## Testing
- no tests were run (not needed for docs)


------
https://chatgpt.com/codex/tasks/task_e_68c8723755148329bc6a78e33c272017