### PR TITLE
Organize gateway fast-track backlog

### DIFF
--- a/plans/gateway/gateway-service.md
+++ b/plans/gateway/gateway-service.md
@@ -35,9 +35,18 @@ Exponer un único edge `/api/*` para el User Portal en smart-edify.com (Squaresp
 - DNS: `api.smart-edify.com` → gateway. Squarespace consume `https://api.smart-edify.com`.
 
 ## Backlog fast-track
+
+### Plataforma
 - [ ] Scaffold (NestJS/Koa/Kong). `/health`.
 - [ ] CORS + OIDC middleware.
 - [ ] Proxy tables y timeouts.
 - [ ] Rate limiting y *request-id*.
 - [ ] OTel exporter y dashboards.
+
+### Integración Squarespace ↔ Gateway
+- [ ] DNS y certificados para `api.smart-edify.com`.
+- [ ] Deploy inicial gateway con `/health` y `/api/auth/*`.
+- [ ] PKCE end-to-end y callback en Squarespace.
+- [ ] Proxies a Assembly, Reservation y Maintenance.
+- [ ] Observabilidad y dashboards.
 - [ ] Canary y *roll-back*.

--- a/plans/gateway/tasks.md
+++ b/plans/gateway/tasks.md
@@ -1,9 +1,0 @@
-# Tareas — Integración Squarespace ↔ Gateway
-
-- DNS y certificados para `api.smart-edify.com`.
-- Deploy inicial gateway con `/health` y `/api/auth/*`.
-- CORS y rate limiting.
-- PKCE end-to-end y callback en Squarespace.
-- Proxies a Assembly, Reservation y Maintenance.
-- Observabilidad y dashboards.
-- Canary y *rollback*.


### PR DESCRIPTION
## Summary
- restore the Backlog fast-track checklist in the gateway plan and keep tasks grouped by plataforma e integración
- keep the Squarespace integration items from the former tasks document under their own subsection

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c86443b19083298a7d6ac7b65cfd3f