### PR TITLE
docs: expand runbook guidance for dlq and auth key rotation

### DIFF
--- a/apps/services/auth-service/README.md
+++ b/apps/services/auth-service/README.md
@@ -101,6 +101,8 @@ HandlerRefresh --> CtxAPI
 - Tokens de recuperación de un solo uso.
 
 ## Rotación de Claves JWT (JWKS)
+> Procedimiento operacional detallado: [Runbook — Rotación de claves (Auth)](../../../docs/runbooks/incident-auth-key-rotation.md).
+
 Se implementó un almacén de claves rotativas en la tabla `auth_signing_keys` con estados `current`, `next`, `retiring`, `expired`.
 
 Endpoints:

--- a/apps/services/tenant-service/README.md
+++ b/apps/services/tenant-service/README.md
@@ -107,6 +107,8 @@ Campos clave:
 
 ## Runbooks Operativos
 
+> Consulta el runbook dedicado: [Reprocesamiento DLQ](../../../docs/runbooks/dlq-reprocessing.md) para el procedimiento completo, validaciones y rollback.
+
 ### 1. Backlog alto (outbox_pending crece)
 1. Verificar errores recientes en logs (filtrar "outbox tick error").
 2. Consultar histogramas: `outbox_event_age_seconds` p95.

--- a/docs/runbooks/dlq-reprocessing.md
+++ b/docs/runbooks/dlq-reprocessing.md
@@ -1,6 +1,90 @@
 # Runbook — Reprocesamiento DLQ
 
-1. Identificar causa raíz en métricas y logs.
-2. Corregir consumidor o datos.
-3. Ejecutar *replay* acotado por `event_id` o rango de tiempo.
-4. Validar idempotencia y consistencia.
+## Purpose
+Restablecer el flujo de eventos movidos a la *dead letter queue* (DLQ) del Tenant Service cuando se detecta acumulación anómala o fallos permanentes. El objetivo es reprocesar sólo los eventos seguros, mantener el tamaño de la cola bajo control y recuperar la consistencia en los consumidores downstream.
+
+## Preconditions
+- Existe una alerta (`outbox_dlq_size > 0` o crecimiento acelerado) o un ticket operativo asignado.
+- Acceso a la base de datos del Tenant Service y permisos para invocar los endpoints `GET/POST/DELETE /outbox/dlq`.
+- Snapshot inicial de la DLQ antes de cualquier acción.
+- Coordinación con el equipo de dominio afectado para validar que la causa raíz está mitigada.
+
+## Step-by-step
+1. **Tomar fotografía inicial y confirmar impacto.**
+   ```bash
+   export TENANT_API="https://tenant-service.prod.smartedify.internal"
+   curl -s "$TENANT_API/metrics" | grep -E 'outbox_dlq_size|outbox_event_age_seconds'
+   curl -s "$TENANT_API/outbox/dlq?limit=500" | jq '.' > dlq-snapshot.json
+   ```
+   - Métricas a observar: `outbox_dlq_size`, `outbox_event_age_seconds_bucket` (p95) y `outbox_reprocessed_total`.
+
+2. **Agrupar eventos y detectar patrón.**
+   ```sql
+   \c tenant_service
+   SELECT type, count(*) AS total, max(last_error) AS sample_error
+   FROM outbox_events_dlq
+   GROUP BY type
+   ORDER BY total DESC;
+   ```
+   Revisa en logs del consumidor correspondiente (`kubectl logs deploy/tenant-consumer -n tenants -f`).
+
+3. **Validar que la causa raíz está resuelta.** Documenta el fix (configuración, despliegue, datos corregidos). Sin mitigación previa, NO reintentar.
+
+4. **Definir lote a reprocesar y crear respaldo.**
+   ```bash
+   jq -r '.items[] | [.id, .type, .failed_at] | @tsv' dlq-snapshot.json > dlq-backup.tsv
+   ```
+   Opcional: genera tabla temporal en DB para rollback.
+
+5. **Reprocesar eventos seleccionados.**
+   - Reproceso individual (útil para validar fix):
+     ```bash
+     EVENT_ID="<uuid>"
+     curl -s -X POST "$TENANT_API/outbox/dlq/$EVENT_ID/reprocess"
+     ```
+   - Reproceso masivo acotado por filtro `type` o lista de IDs:
+     ```bash
+     jq -r '.items[] | select(.type=="tenant.created") | .id' dlq-snapshot.json \
+       | while read id; do
+           curl -s -X POST "$TENANT_API/outbox/dlq/$id/reprocess";
+         done
+     ```
+   Observa que `outbox_reprocessed_total` debe incrementarse conforme se vacía la cola.
+
+6. **Purgar residuales antiguos (si procede).**
+   ```bash
+   OLDER_THAN=$(date -u -d '14 days ago' +%FT%TZ)
+   curl -s -X DELETE "$TENANT_API/outbox/dlq?olderThan=$OLDER_THAN"
+   ```
+   Esta acción incrementa `outbox_dlq_purged_total` y mantiene la cola limpia tras validar que no quedan eventos reprocesables.
+
+## Validation
+- `curl -s "$TENANT_API/metrics" | grep outbox_dlq_size` → debe tender a `0` o al umbral acordado (< 10 eventos).
+- `curl -s "$TENANT_API/metrics" | grep outbox_reprocessed_total` → el contador debe haber incrementado igual al número de eventos reintentados exitosamente.
+- Consulta SQL final:
+  ```sql
+  SELECT count(*) FROM outbox_events_dlq;
+  ```
+  Asegura que sólo queden eventos con causa raíz abierta o aprobados para retenerse.
+- Revisa dashboards de consumidor downstream para confirmar que no hay nuevos errores asociados al lote reprocesado (por ejemplo, `broker_consumer_lag_max` estable).
+
+## Rollback
+1. Si los reprocesos generan fallos, detén el bucle (`Ctrl+C`) e incrementa `TENANT_DLQ_REPROCESS_DISABLED=true` (feature flag) para pausar reintentos automáticos.
+2. Restaura eventos reinsertándolos en la DLQ usando el respaldo tomado:
+   ```bash
+   psql "$TENANT_DB_URL" <<'SQL'
+   CREATE TEMP TABLE tmp_dlq(id uuid, type text, failed_at timestamptz);
+   \copy tmp_dlq FROM 'dlq-backup.tsv'
+   INSERT INTO outbox_events_dlq (id, aggregate_type, aggregate_id, type, payload, created_at, failed_at, last_error, retry_count, original_status, moved_reason)
+   SELECT d.id, e.aggregate_type, e.aggregate_id, e.type, e.payload, e.created_at, NOW(), e.last_error, e.retry_count, 'failed_permanent', 'rollback'
+   FROM tmp_dlq d
+   JOIN outbox_events e ON e.id = d.id;
+   SQL
+   ```
+3. Restablece métricas de control confirmando que `outbox_dlq_size` vuelve al valor previo a la intervención.
+4. Escala al equipo de dominio para corregir definitivamente la causa antes de un nuevo intento.
+
+## Contacts
+- **On-call Plataforma**: `#oncall-plataforma` (Slack) / oncall@smartedify.com
+- **Equipo Tenant Service**: tenant-core@smartedify.com
+- **Observabilidad**: `#obs-alerts` para dashboards y soporte de métricas

--- a/docs/runbooks/incident-auth-key-rotation.md
+++ b/docs/runbooks/incident-auth-key-rotation.md
@@ -1,8 +1,103 @@
 # Runbook — Rotación de claves (Auth)
 
-1. Generar `next` y publicar en JWKS.
-2. Esperar propagación 10 min.
-3. Promover `next`→`current`.
-4. Marcar antigua como `retiring`. Mantener 24 h.
-5. Revocar *refresh tokens* emitidos antes de `current`.
-6. Verificar métricas de verificación por `kid`.
+## Purpose
+Ejecutar una rotación controlada de las claves RSA utilizadas por Auth Service para firmar tokens JWT. El objetivo es mitigar exposiciones, cumplir con políticas de rotación y garantizar que los consumidores actualicen el JWKS sin pérdida de disponibilidad.
+
+## Preconditions
+- Hay un motivo válido (compromiso, política de 90 días o auditoría) documentado en el ticket.
+- Acceso a la base de datos `auth_service` y al endpoint administrativo `POST /admin/rotate-keys` (expuesto internamente).
+- Capacidad para ejecutar comandos `openssl`, `uuidgen` y `psql` desde un entorno seguro.
+- Confirmación de que el *cache* y los consumidores aceptan claves en estados `current`, `next` y `retiring`.
+
+## Step-by-step
+1. **Revisar el estado actual y capturar snapshot.**
+   ```bash
+   export AUTH_API="https://auth-service.prod.smartedify.internal"
+   curl -s "$AUTH_API/metrics" | grep auth_jwks_keys_total
+   psql "$AUTH_DB_URL" -c "SELECT kid, status, promoted_at, retiring_at FROM auth_signing_keys ORDER BY created_at DESC;"
+   curl -s "$AUTH_API/.well-known/jwks.json" | jq '.' > jwks-before.json
+   ```
+   Confirma que existe una clave `current` válida y, si ya hay `next`, registra su `kid`.
+
+2. **Generar una nueva clave `next` segura (si no existe o está comprometida).**
+   - **Opción preferida (dentro del pod):**
+     ```bash
+     kubectl -n auth exec deploy/auth-service -- node -e "import('./dist/internal/security/keys.js').then(m => m.getNextKey(true).then(()=>process.exit(0)))"
+     ```
+     El comando utiliza el helper `getNextKey(true)` para crear y persistir automáticamente una nueva clave `next` usando la lógica del servicio.
+   - **Alternativa manual (fuera del pod) si la anterior falla:**
+     ```bash
+     NEXT_KID=$(uuidgen)
+     openssl genrsa -out next-private.pem 2048
+     openssl rsa -in next-private.pem -pubout -out next-public.pem
+     PRIV_ESCAPED=$(python3 - <<'PY'
+from pathlib import Path
+print(Path('next-private.pem').read_text().replace("'", "''"))
+PY
+)
+     PUB_ESCAPED=$(python3 - <<'PY'
+from pathlib import Path
+print(Path('next-public.pem').read_text().replace("'", "''"))
+PY
+)
+     psql "$AUTH_DB_URL" <<SQL
+     INSERT INTO auth_signing_keys (kid, pem_private, pem_public, status)
+     VALUES ('$NEXT_KID', '$PRIV_ESCAPED', '$PUB_ESCAPED', 'next');
+     SQL
+     rm next-private.pem next-public.pem
+     ```
+   Verifica que la métrica `auth_jwks_keys_total{status="next"}` refleje el nuevo valor (puede tardar ~30 s por el *cache* interno).
+
+3. **Esperar propagación y verificar JWKS publicado.**
+   ```bash
+   sleep 600  # 10 minutos
+   diff -u jwks-before.json <(curl -s "$AUTH_API/.well-known/jwks.json" | jq '.')
+   ```
+   Asegúrate de que el `kid` nuevo aparezca con estado `next` y que los consumidores críticos (API Gateway, Tenant Service) ya lo hayan descargado.
+
+4. **Promover `next` a `current` y generar nueva `next`.**
+   ```bash
+   curl -s -X POST "$AUTH_API/admin/rotate-keys" | jq '.'
+   curl -s "$AUTH_API/metrics" | grep auth_jwks_rotation_total
+   ```
+   - Espera confirmación HTTP 200.
+   - El contador `auth_jwks_rotation_total` debe incrementarse en 1.
+   - En la tabla `auth_signing_keys`, valida que la antigua `current` esté en estado `retiring` y la nueva tenga `promoted_at` reciente.
+
+5. **Revocar credenciales anteriores y comunicar.**
+   ```bash
+   export AUTH_REDIS_URL="redis://auth-redis.prod.smartedify.internal:6379"
+   redis-cli -u "$AUTH_REDIS_URL" --scan --pattern 'refresh:*' | \
+     xargs -r -n200 redis-cli -u "$AUTH_REDIS_URL" DEL
+   redis-cli -u "$AUTH_REDIS_URL" --scan --pattern 'rotated:*' | \
+     xargs -r -n200 redis-cli -u "$AUTH_REDIS_URL" DEL
+   kubectl -n auth logs deploy/auth-service | grep "JWKS" | tail -n20
+   ```
+   Notifica a los servicios consumidores para que invaliden cachés locales y verifiquen la aceptación del nuevo `kid`.
+
+## Validation
+- `curl -s "$AUTH_API/.well-known/jwks.json" | jq '.keys[].kid'` → incluye el nuevo `kid` como `current` y mantiene el anterior como `retiring` durante el periodo de gracia.
+- Métrica `auth_jwks_keys_total{status="current"}` debe permanecer en `1`, `auth_jwks_keys_total{status="retiring"}` en `1` (temporal) y `auth_jwks_keys_total{status="next"}` en `1` tras la rotación automática del endpoint.
+- Ejecuta un flujo de login para confirmar que los tokens se firman con el nuevo `kid`:
+  ```bash
+  NEW_KID=$(curl -s "$AUTH_API/login" -d '{"email":"ops-check@example.com","password":"<SECRET>"}' | jq -r '.access_token' | cut -d'.' -f2 | base64 -d | jq -r '.kid')
+  ```
+  Debe coincidir con la clave `current` registrada.
+
+## Rollback
+1. Identifica el `kid` previo (estado `retiring`).
+2. Restituye el estado en la base de datos:
+   ```bash
+   psql "$AUTH_DB_URL" <<SQL
+   UPDATE auth_signing_keys SET status='current', promoted_at=NOW() WHERE kid='<KID_RETIRING>'; 
+   UPDATE auth_signing_keys SET status='retiring', retiring_at=NOW() WHERE kid='<KID_NUEVO>'; 
+   DELETE FROM auth_signing_keys WHERE status='next' AND kid <> '<KID_RETIRING>';
+   SQL
+   ```
+3. Limpia caches aplicando `POST /admin/rotate-keys` para recrear una nueva `next` segura una vez contenido el incidente.
+4. Regenera *refresh tokens* afectados y comunica al equipo de seguridad el rollback ejecutado.
+
+## Contacts
+- **On-call Seguridad**: `#sec-oncall` / security@smartedify.com
+- **Equipo Auth Service**: auth-team@smartedify.com (propietarios del servicio y esquema)
+- **SRE Plataforma**: `#oncall-plataforma` para soporte en despliegue y métricas


### PR DESCRIPTION
## Summary
- restructured the DLQ reprocessing runbook with detailed purpose, prerequisites, procedures, validation, rollback, and contacts plus concrete command and metric guidance
- enriched the Auth key rotation runbook with full operational steps including automation options, verification metrics, rollback, and contact references
- cross-linked the updated runbooks from the tenant-service and auth-service READMEs for quick operator access

## Testing
- not run (docs only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8a36aa524832993b560ff1391bb83