### PR TITLE
docs: expand eventing and openapi guidelines

### DIFF
--- a/docs/eventing-guidelines.md
+++ b/docs/eventing-guidelines.md
@@ -1,9 +1,55 @@
 # Guía de eventos (NATS)
 
-## Convenciones
-- Subject: `v1.<dominio>.<evento>`
-- `data`: objeto con `id`, `occurred_at`, `actor`, `tenant_id` y payload.
-- `event_id` UUID para idempotencia.
+## Convenciones de nombres
+- Subjects con formato `v<version>.<dominio>.<agregado>.<accion>` para facilitar filtros con comodines (`v1.ventas.orden.*`).
+- Dominios y agregados en inglés en singular (`billing.invoice`), acciones en pasado (`created`, `updated`).
+- Identificadores de actores (`actor_id`, `tenant_id`) siempre en snake_case y UUID v4 salvo proveedores externos.
+- El `event_id` es un UUID v7 y se usa como *deduplication key* en consumidores idempotentes.
 
-## DLQ
-- Cola por servicio `dlq.<service>`; *retry* exponencial con *jitter*. Runbook asociado.
+## Versionado de subjects y payloads
+- Incrementar la versión del subject cuando el *payload* cambia de forma incompatible (p. ej. campos renombrados o eliminados).
+- Los cambios compatibles (añadir campos opcionales) mantienen la versión y se documentan en el registro de esquemas.
+- Mantener vivas al menos dos versiones durante la migración; los productores publican en ambas y los consumidores actualizan primero.
+
+## Estructura del evento
+- `data` debe ser un objeto con `id`, `occurred_at`, `actor`, `tenant_id` y `payload`.
+- `occurred_at` en ISO8601 con zona UTC (`2024-03-15T12:34:56Z`).
+- `payload` encapsula el dominio del evento y nunca expone PII sin clasificación previa.
+- Ejemplo:
+
+```json
+{
+  "subject": "v1.billing.invoice.created",
+  "event_id": "018f1c90-d64a-72c2-8dd6-71a9e1d2e220",
+  "occurred_at": "2024-03-15T12:34:56Z",
+  "actor": {"id": "7c38...", "type": "system"},
+  "tenant_id": "8b3f...",
+  "data": {
+    "id": "inv-10293",
+    "occurred_at": "2024-03-15T12:34:56Z",
+    "actor": {"id": "7c38...", "type": "system"},
+    "tenant_id": "8b3f...",
+    "payload": {
+      "number": "INV-2024-001",
+      "total": 199.99,
+      "currency": "USD"
+    }
+  }
+}
+```
+
+## Validación de esquemas
+- Cada subject tiene un JSON Schema almacenado en `specs/events/<dominio>/<subject>.schema.json` versionado en Git.
+- Los productores validan el payload antes de publicar usando AJV (Node) o `jsonschema` (Python).
+- Los consumidores ejecutan *contract tests* contra el mismo schema y rechazan mensajes que no validan.
+- Los *pipelines* de CI ejecutan `npm run lint:events` para validar esquemas y diffs.
+
+## Manejo de errores y DLQ
+- En caso de validación fallida, emitir `nack` y registrar el `event_id` + motivo en observabilidad (Log + Trace).
+- Retentar con *backoff* exponencial con *jitter* hasta 5 veces antes de enrutar a `dlq.<servicio>`.
+- Documentar un *runbook* por cola DLQ con pasos para reprocesar (`nats stream replay ...`).
+- Ejemplo de flujo de manejo de error:
+  1. Consumidor recibe `v1.billing.invoice.created` y falla validación.
+  2. Envía `nack`, registra métrica `events.validation_error` con etiquetas `subject`, `tenant_id`.
+  3. Tras 5 intentos, se publica en `dlq.billing` y se abre alerta en PagerDuty.
+  4. Operaciones usa el runbook para corregir datos y reprocesar el evento.

--- a/docs/openapi-guidelines.md
+++ b/docs/openapi-guidelines.md
@@ -1,6 +1,30 @@
 # Guía OpenAPI
 
-- Un archivo por servicio, versión `/v1`.
-- `components/schemas` compartidos dentro del servicio.
-- `operationId` único y testeado con contract tests.
-- Lint con Spectral. Preview Redoc en PR.
+## Estilo y organización
+- Un archivo por servicio siguiendo la convención `openapi/<servicio>/openapi.yaml`; expone rutas bajo `/v1`.
+- Recursos en plural y en minúscula (`/students`, `/students/{student_id}`) con respuestas JSON en camelCase.
+- `operationId` único por operación (`<Recurso><Accion>`), reutilizado en pruebas de contrato y SDKs.
+- Documentar todos los códigos de estado esperados y mensajes de error con `content.application/json`.
+- Usar `components/parameters` para filtros comunes y `components/responses` para paginación, errores y `401/403`.
+
+## Metadatos obligatorios
+- `info`: `title`, `version`, `description`, `contact.email`, `license` y `termsOfService`.
+- `servers`: al menos `production` y `staging` con variables `{tenant}` si aplica multi-tenant.
+- `tags`: describen dominios funcionales y tienen `description` para la documentación.
+- Incluir `externalDocs` apuntando a la wiki del servicio si existe.
+
+## Componentes y reutilización
+- `components/schemas` compartidos dentro del servicio; no se repiten definiciones entre endpoints.
+- Para enumeraciones reutilizables, definir `x-enum-varnames` y ejemplos con `x-examples`.
+- Los cambios compatibles incrementan `info.version` menor (`1.2.0` → `1.3.0`); cambios incompatibles incrementan versión mayor.
+
+## Pruebas y control de calidad
+- Validar el spec con `npm run lint:openapi` (Spectral) en CI y antes de hacer merge.
+- Ejecutar contract tests que verifiquen `operationId` y respuestas con JSON Schema derivado de `components/schemas`.
+- Generar documentación previa al merge con Redocly CLI (`npx @redocly/cli build-docs`) y adjuntar el HTML en la PR.
+- Revisar breaking changes usando `npx openapi-diff <base> <head>` cuando se actualicen versiones.
+
+## Herramientas recomendadas
+- [Spectral](https://github.com/stoplightio/spectral) para linting y reglas personalizadas.
+- [Redoc](https://github.com/Redocly/redoc) para visualización y previsualización de los specs.
+- [OpenAPI Generator](https://openapi-generator.tech) para generar SDKs y asegurar que los `schemas` sean consumibles.


### PR DESCRIPTION
## Summary
- expand the NATS eventing guide with naming, versioning, schema validation, and error handling practices
- document OpenAPI style conventions, required metadata, validation checks, and tooling references

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c8a9c9b83c8329bd50bc3e7cb5d27a