### PR TITLE
feat(auth): add oauth2 oidc endpoints

### DIFF
--- a/apps/services/auth-service/api/openapi.yaml
+++ b/apps/services/auth-service/api/openapi.yaml
@@ -1,8 +1,152 @@
 openapi: 3.0.3
 info:
   title: Auth Service API
-  version: 1.1.0
+  version: 1.2.0
 paths:
+  /authorize:
+    get:
+      summary: Inicio del flujo Authorization Code con PKCE
+      description: |
+        Endpoint OIDC/OAuth2 que valida la sesión del usuario (Bearer access token) y
+        redirige al `redirect_uri` registrado con un `code` de autorización de un solo uso.
+      parameters:
+        - in: query
+          name: response_type
+          schema:
+            type: string
+            enum: [code]
+          required: true
+        - in: query
+          name: client_id
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: redirect_uri
+          schema:
+            type: string
+            format: uri
+          required: true
+        - in: query
+          name: scope
+          schema:
+            type: string
+            description: Scopes separados por espacio. Debe incluir `openid`.
+        - in: query
+          name: state
+          schema:
+            type: string
+          description: Valor opaco devuelto sin cambios al cliente.
+        - in: query
+          name: code_challenge
+          schema:
+            type: string
+          description: PKCE code challenge (43-128 chars Base64URL).
+        - in: query
+          name: code_challenge_method
+          schema:
+            type: string
+            enum: [S256, plain]
+          description: Método PKCE utilizado. Por defecto `plain`.
+        - in: query
+          name: nonce
+          schema:
+            type: string
+          description: Nonce opcional propagado al `id_token`.
+      responses:
+        '302':
+          description: Redirección al `redirect_uri` con el código de autorización.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: URI con parámetros `code` y, si aplica, `state`.
+        '400':
+          description: Solicitud inválida.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Sesión inválida o ausente.
+  /token:
+    post:
+      summary: Emite tokens de acceso/refresh a partir de un Authorization Code o Refresh Token
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
+      responses:
+        '200':
+          description: Tokens emitidos correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: Grant inválido o parámetros incompletos.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Cliente inválido.
+  /userinfo:
+    get:
+      summary: Recupera claims del usuario autenticado
+      responses:
+        '200':
+          description: Información básica del usuario según scopes concedidos.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserInfoResponse'
+        '401':
+          description: Access token inválido o expirado.
+  /introspection:
+    post:
+      summary: Introspección de tokens (RFC 7662)
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IntrospectionRequest'
+      responses:
+        '200':
+          description: Resultado de introspección.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntrospectionResponse'
+        '401':
+          description: Cliente inválido.
+  /revocation:
+    post:
+      summary: Revocación de tokens (RFC 7009)
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RevocationRequest'
+      responses:
+        '200':
+          description: Token revocado (o token inexistente).
+        '401':
+          description: Cliente inválido.
+  /.well-known/openid-configuration:
+    get:
+      summary: Documento de discovery OIDC
+      responses:
+        '200':
+          description: Metadata publicada para clientes OIDC.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenIdConfiguration'
   /register:
     post:
       summary: Registro de usuario
@@ -114,6 +258,15 @@ paths:
                   - $ref: '#/components/schemas/PermissionsByRoleResponse'
 components:
   schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        error_description:
+          type: string
+      required:
+        - error
     RegisterRequest:
       type: object
       properties:
@@ -198,7 +351,6 @@ components:
         - refresh_token
         - token_type
         - expires_in
-        - roles
     LogoutRequest:
       type: object
       properties:
@@ -258,3 +410,199 @@ components:
       required:
         - role
         - permissions
+    TokenRequest:
+      type: object
+      properties:
+        grant_type:
+          type: string
+          enum: [authorization_code, refresh_token]
+        code:
+          type: string
+          description: Authorization code recibido en `/authorize`.
+        redirect_uri:
+          type: string
+          format: uri
+        code_verifier:
+          type: string
+          description: Verificador PKCE usado cuando el grant es `authorization_code`.
+        client_id:
+          type: string
+        client_secret:
+          type: string
+        refresh_token:
+          type: string
+          description: Token de refresh a rotar cuando `grant_type=refresh_token`.
+        scope:
+          type: string
+          description: Subconjunto opcional de scopes al refrescar.
+      required:
+        - grant_type
+    TokenResponse:
+      type: object
+      properties:
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+        token_type:
+          type: string
+          enum: [Bearer]
+        expires_in:
+          type: integer
+        scope:
+          type: string
+        id_token:
+          type: string
+          description: Presente cuando el scope incluye `openid`.
+      required:
+        - access_token
+        - refresh_token
+        - token_type
+        - expires_in
+    UserInfoResponse:
+      type: object
+      properties:
+        sub:
+          type: string
+        tenant_id:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        scope:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        email_verified:
+          type: boolean
+      required:
+        - sub
+        - tenant_id
+        - roles
+    IntrospectionRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        token_type_hint:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+      required:
+        - token
+    IntrospectionResponse:
+      type: object
+      properties:
+        active:
+          type: boolean
+        token_type:
+          type: string
+        client_id:
+          type: string
+        scope:
+          type: string
+        sub:
+          type: string
+        iss:
+          type: string
+        exp:
+          type: integer
+        iat:
+          type: integer
+        aud:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+        tenant_id:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+      required:
+        - active
+    RevocationRequest:
+      type: object
+      properties:
+        token:
+          type: string
+        token_type_hint:
+          type: string
+        client_id:
+          type: string
+        client_secret:
+          type: string
+      required:
+        - token
+    OpenIdConfiguration:
+      type: object
+      properties:
+        issuer:
+          type: string
+        authorization_endpoint:
+          type: string
+        token_endpoint:
+          type: string
+        userinfo_endpoint:
+          type: string
+        jwks_uri:
+          type: string
+        introspection_endpoint:
+          type: string
+        revocation_endpoint:
+          type: string
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        grant_types_supported:
+          type: array
+          items:
+            type: string
+        scopes_supported:
+          type: array
+          items:
+            type: string
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
+        token_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        response_modes_supported:
+          type: array
+          items:
+            type: string
+        subject_types_supported:
+          type: array
+          items:
+            type: string
+        id_token_signing_alg_values_supported:
+          type: array
+          items:
+            type: string
+        claims_supported:
+          type: array
+          items:
+            type: string
+      required:
+        - issuer
+        - authorization_endpoint
+        - token_endpoint
+        - jwks_uri
+        - response_types_supported
+        - grant_types_supported
+        - scopes_supported
+        - code_challenge_methods_supported
+        - token_endpoint_auth_methods_supported
+        - id_token_signing_alg_values_supported

--- a/apps/services/auth-service/cmd/server/main.ts
+++ b/apps/services/auth-service/cmd/server/main.ts
@@ -19,6 +19,12 @@ import { logoutHandler } from '../../internal/adapters/http/logout.handler';
 import { forgotPasswordHandler } from '../../internal/adapters/http/forgot-password.handler';
 import { resetPasswordHandler } from '../../internal/adapters/http/reset-password.handler';
 import { rolesHandler, permissionsHandler } from '../../internal/adapters/http/roles-permissions.handler';
+import { authorizeHandler } from '../../internal/adapters/http/authorize.handler';
+import { tokenHandler } from '../../internal/adapters/http/token.handler';
+import { userinfoHandler } from '../../internal/adapters/http/userinfo.handler';
+import { introspectionHandler } from '../../internal/adapters/http/introspection.handler';
+import { revocationHandler } from '../../internal/adapters/http/revocation.handler';
+import { openIdConfigurationHandler } from '../../internal/adapters/http/openid-configuration.handler';
 import pool from '../../internal/adapters/db/pg.adapter';
 import { redisPing } from '../../internal/adapters/redis/redis.adapter';
 import { loginRateLimiter, bruteForceGuard } from '../../internal/middleware/rate-limit';
@@ -130,6 +136,7 @@ export const app = express();
 // Export util para tests que permita limpiar intervalo si en algún momento se inicializa
 export async function _cleanupMetrics() { /* noop actual (mantener API por si cambiamos) */ }
 app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 // Middleware request-id
 app.use((req, res, next) => {
@@ -224,6 +231,8 @@ app.get('/.well-known/jwks.json', async (_req, res) => {
   }
 });
 
+app.get('/.well-known/openid-configuration', openIdConfigurationHandler);
+
 // Rotación manual (MVP) - proteger en producción
 app.post('/admin/rotate-keys', async (_req, res) => {
   try {
@@ -244,6 +253,11 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Endpoints principales
+app.get('/authorize', authorizeHandler);
+app.post('/token', tokenHandler);
+app.get('/userinfo', userinfoHandler);
+app.post('/introspection', introspectionHandler);
+app.post('/revocation', revocationHandler);
 app.post('/register', registerHandler);
 app.post('/login', loginRateLimiter, bruteForceGuard, loginHandler);
 app.post('/logout', logoutHandler);

--- a/apps/services/auth-service/internal/adapters/http/authorize.dto.ts
+++ b/apps/services/auth-service/internal/adapters/http/authorize.dto.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const codePattern = /^[A-Za-z0-9\-._~]+$/;
+
+export const AuthorizeRequestSchema = z.object({
+  response_type: z.literal('code'),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  scope: z.string().optional(),
+  state: z.string().optional(),
+  code_challenge: z
+    .string()
+    .min(43)
+    .max(128)
+    .regex(codePattern, 'PKCE code_challenge contiene caracteres inválidos')
+    .optional(),
+  code_challenge_method: z.enum(['S256', 'plain']).optional(),
+  nonce: z.string().optional(),
+  prompt: z.string().optional(),
+  login_hint: z.string().optional()
+});
+
+export type AuthorizeRequest = z.infer<typeof AuthorizeRequestSchema>;

--- a/apps/services/auth-service/internal/adapters/http/authorize.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/authorize.handler.ts
@@ -1,0 +1,149 @@
+import { randomBytes } from 'crypto';
+import { Request, Response } from 'express';
+import { AuthorizeRequestSchema } from './authorize.dto';
+import {
+  clientSupportsResponseType,
+  findClientById,
+  getDefaultScopes,
+  hasAllScopes,
+  isRedirectUriAllowed,
+  normalizeScopes
+} from '../../oauth/clients';
+import { verifyAccess } from '../../security/jwt';
+import { saveAuthorizationCode } from '../redis/redis.adapter';
+
+const CODE_TTL_SECONDS = 600;
+
+function firstParam(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value[0];
+  return undefined;
+}
+
+function generateAuthorizationCode(): string {
+  return randomBytes(32)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export async function authorizeHandler(req: Request, res: Response) {
+  const input = {
+    response_type: firstParam(req.query.response_type) || undefined,
+    client_id: firstParam(req.query.client_id) || undefined,
+    redirect_uri: firstParam(req.query.redirect_uri) || undefined,
+    scope: firstParam(req.query.scope) || undefined,
+    state: firstParam(req.query.state) || undefined,
+    code_challenge: firstParam(req.query.code_challenge) || undefined,
+    code_challenge_method: firstParam(req.query.code_challenge_method) || undefined,
+    nonce: firstParam(req.query.nonce) || undefined,
+    prompt: firstParam(req.query.prompt) || undefined,
+    login_hint: firstParam(req.query.login_hint) || undefined
+  };
+  const parseResult = AuthorizeRequestSchema.safeParse(input);
+  if (!parseResult.success) {
+    return res.status(400).json({
+      error: 'invalid_request',
+      details: parseResult.error.flatten()
+    });
+  }
+  const data = parseResult.data;
+  const client = findClientById(data.client_id);
+  if (!client) {
+    return res.status(400).json({ error: 'invalid_client' });
+  }
+  if (!clientSupportsResponseType(client, data.response_type)) {
+    return res.status(400).json({ error: 'unsupported_response_type' });
+  }
+  if (!isRedirectUriAllowed(client, data.redirect_uri)) {
+    return res.status(400).json({ error: 'invalid_redirect_uri' });
+  }
+
+  const scopes = normalizeScopes(data.scope);
+  const effectiveScopes = scopes.length ? scopes : getDefaultScopes(client);
+  if (!hasAllScopes(client, effectiveScopes)) {
+    return res.status(400).json({ error: 'invalid_scope' });
+  }
+  if (!effectiveScopes.includes('openid')) {
+    return res.status(400).json({ error: 'invalid_scope', error_description: 'openid requerido' });
+  }
+
+  if (client.requirePkce && !data.code_challenge) {
+    return res.status(400).json({ error: 'invalid_request', error_description: 'code_challenge requerido' });
+  }
+  const rawPkceMethod = data.code_challenge ? (data.code_challenge_method || 'plain').toUpperCase() : undefined;
+  if (rawPkceMethod && !['PLAIN', 'S256'].includes(rawPkceMethod)) {
+    return res.status(400).json({ error: 'invalid_request', error_description: 'code_challenge_method inválido' });
+  }
+  if (client.requirePkce && rawPkceMethod !== 'S256') {
+    return res.status(400).json({ error: 'invalid_request', error_description: 'code_challenge_method debe ser S256' });
+  }
+  const pkceMethod = data.code_challenge
+    ? rawPkceMethod === 'S256'
+      ? 'S256'
+      : 'plain'
+    : undefined;
+
+  const authorization = req.headers.authorization || req.headers.Authorization;
+  if (!authorization || typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'login_required' });
+  }
+  const token = authorization.slice('Bearer '.length).trim();
+  if (!token) {
+    return res.status(401).json({ error: 'login_required' });
+  }
+
+  let payload: any;
+  try {
+    payload = await verifyAccess(token);
+  } catch (e) {
+    return res.status(401).json({ error: 'invalid_token' });
+  }
+
+  if (!payload?.sub || typeof payload.sub !== 'string') {
+    return res.status(400).json({ error: 'invalid_token', error_description: 'sub ausente' });
+  }
+
+  const roles = Array.isArray(payload.roles)
+    ? payload.roles
+    : typeof payload.roles === 'string'
+    ? [payload.roles]
+    : [];
+  const tenantId = typeof payload.tenant_id === 'string' ? payload.tenant_id : 'default';
+  const authTime = typeof payload.auth_time === 'number'
+    ? payload.auth_time
+    : typeof payload.iat === 'number'
+    ? payload.iat
+    : Math.floor(Date.now() / 1000);
+
+  const code = generateAuthorizationCode();
+  const scopeString = effectiveScopes.join(' ');
+  await saveAuthorizationCode(
+    code,
+    {
+      clientId: client.clientId,
+      redirectUri: data.redirect_uri,
+      scope: scopeString,
+      codeChallenge: data.code_challenge || null,
+      codeChallengeMethod: pkceMethod || null,
+      userId: payload.sub,
+      tenantId,
+      roles,
+      nonce: data.nonce || null,
+      authTime,
+      issuedAt: Date.now()
+    },
+    CODE_TTL_SECONDS
+  );
+
+  const redirectUri = new URL(data.redirect_uri);
+  redirectUri.searchParams.set('code', code);
+  if (data.state) {
+    redirectUri.searchParams.set('state', data.state);
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+  return res.redirect(302, redirectUri.toString());
+}

--- a/apps/services/auth-service/internal/adapters/http/introspection.dto.ts
+++ b/apps/services/auth-service/internal/adapters/http/introspection.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const IntrospectionRequestSchema = z.object({
+  token: z.string().min(1),
+  token_type_hint: z.string().optional(),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional()
+});
+
+export type IntrospectionRequest = z.infer<typeof IntrospectionRequestSchema>;

--- a/apps/services/auth-service/internal/adapters/http/introspection.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/introspection.handler.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express';
+import { IntrospectionRequestSchema } from './introspection.dto';
+import { resolveClientAuthentication } from '../../oauth/clients';
+import { verifyAccess, verifyRefresh } from '../../security/jwt';
+import { getIssuer } from '../../config/issuer';
+
+export async function introspectionHandler(req: Request, res: Response) {
+  const parseResult = IntrospectionRequestSchema.safeParse(req.body || {});
+  if (!parseResult.success) {
+    return res.status(400).json({ error: 'invalid_request', details: parseResult.error.flatten() });
+  }
+  const data = parseResult.data;
+  const authHeader = typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined;
+  const clientAuth = resolveClientAuthentication({
+    authorizationHeader: authHeader,
+    bodyClientId: data.client_id,
+    bodyClientSecret: data.client_secret
+  });
+  if (!clientAuth) {
+    return res.status(401).json({ error: 'invalid_client' });
+  }
+
+  const token = data.token;
+  let decoded: any;
+  let tokenType: 'access_token' | 'refresh_token';
+  try {
+    decoded = await verifyAccess(token);
+    tokenType = 'access_token';
+  } catch (accessErr) {
+    try {
+      decoded = await verifyRefresh(token);
+      tokenType = 'refresh_token';
+    } catch (refreshErr) {
+      return res.json({ active: false });
+    }
+  }
+
+  const response: Record<string, any> = {
+    active: true,
+    token_type: tokenType,
+    client_id: decoded.client_id || clientAuth.client.clientId,
+    scope: typeof decoded.scope === 'string' ? decoded.scope : undefined,
+    sub: decoded.sub,
+    iss: getIssuer(),
+    exp: decoded.exp,
+    iat: decoded.iat,
+    aud: decoded.aud,
+    tenant_id: decoded.tenant_id,
+    roles: decoded.roles
+  };
+
+  Object.keys(response).forEach(key => {
+    if (response[key] === undefined || response[key] === null) {
+      delete response[key];
+    }
+  });
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+  return res.json(response);
+}

--- a/apps/services/auth-service/internal/adapters/http/openid-configuration.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/openid-configuration.handler.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import { getIssuer, issuerUrl } from '../../config/issuer';
+import { getSupportedScopes, getTokenEndpointAuthMethods, listOAuthClients } from '../../oauth/clients';
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+export async function openIdConfigurationHandler(_req: Request, res: Response) {
+  const issuer = getIssuer();
+  const clients = listOAuthClients();
+  const responseTypes = unique(clients.flatMap(client => client.responseTypes));
+  const grantTypes = unique(clients.flatMap(client => client.grantTypes));
+  const scopes = getSupportedScopes();
+  const codeChallengeMethods = new Set<string>();
+  let allowPlain = false;
+  for (const client of clients) {
+    if (client.requirePkce) {
+      codeChallengeMethods.add('S256');
+    } else {
+      allowPlain = true;
+    }
+  }
+  if (allowPlain) codeChallengeMethods.add('plain');
+  if (!codeChallengeMethods.size) {
+    codeChallengeMethods.add('S256');
+  }
+
+  const metadata = {
+    issuer,
+    authorization_endpoint: issuerUrl('/authorize'),
+    token_endpoint: issuerUrl('/token'),
+    userinfo_endpoint: issuerUrl('/userinfo'),
+    jwks_uri: issuerUrl('/.well-known/jwks.json'),
+    introspection_endpoint: issuerUrl('/introspection'),
+    revocation_endpoint: issuerUrl('/revocation'),
+    response_types_supported: responseTypes.length ? responseTypes : ['code'],
+    grant_types_supported: grantTypes.length ? grantTypes : ['authorization_code', 'refresh_token'],
+    scopes_supported: scopes.length ? scopes : ['openid', 'profile', 'email', 'offline_access'],
+    code_challenge_methods_supported: Array.from(codeChallengeMethods.values()),
+    token_endpoint_auth_methods_supported: getTokenEndpointAuthMethods(),
+    response_modes_supported: ['query'],
+    subject_types_supported: ['public'],
+    id_token_signing_alg_values_supported: ['RS256'],
+    claims_supported: ['sub', 'tenant_id', 'roles', 'email', 'name', 'scope']
+  };
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+  return res.json(metadata);
+}

--- a/apps/services/auth-service/internal/adapters/http/revocation.dto.ts
+++ b/apps/services/auth-service/internal/adapters/http/revocation.dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const RevocationRequestSchema = z.object({
+  token: z.string().min(1),
+  token_type_hint: z.string().optional(),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional()
+});
+
+export type RevocationRequest = z.infer<typeof RevocationRequestSchema>;

--- a/apps/services/auth-service/internal/adapters/http/revocation.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/revocation.handler.ts
@@ -1,0 +1,86 @@
+import { Request, Response } from 'express';
+import { RevocationRequestSchema } from './revocation.dto';
+import { resolveClientAuthentication } from '../../oauth/clients';
+import { verifyAccess, verifyRefresh } from '../../security/jwt';
+import {
+  addToRevocationList,
+  deleteSession,
+  markRefreshRotated,
+  revokeRefreshToken
+} from '../redis/redis.adapter';
+import { tokenRevokedCounter } from '../../../cmd/server/main';
+
+function ttlFromExp(exp?: number): number {
+  if (!exp || typeof exp !== 'number') return 0;
+  const seconds = Math.floor(exp - Date.now() / 1000);
+  return seconds > 0 ? seconds : 0;
+}
+
+export async function revocationHandler(req: Request, res: Response) {
+  const parseResult = RevocationRequestSchema.safeParse(req.body || {});
+  if (!parseResult.success) {
+    return res.status(400).json({ error: 'invalid_request', details: parseResult.error.flatten() });
+  }
+  const data = parseResult.data;
+  const authHeader = typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined;
+  const clientAuth = resolveClientAuthentication({
+    authorizationHeader: authHeader,
+    bodyClientId: data.client_id,
+    bodyClientSecret: data.client_secret
+  });
+  if (!clientAuth) {
+    return res.status(401).json({ error: 'invalid_client' });
+  }
+
+  const token = data.token;
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+
+  try {
+    const decoded: any = await verifyRefresh(token);
+    if (decoded?.jti) {
+      const ttl = Math.max(ttlFromExp(decoded.exp), 1);
+      try {
+        await revokeRefreshToken(decoded.jti);
+      } catch (e) {
+        if (process.env.AUTH_TEST_LOGS) console.error('[revocation] revokeRefreshToken failed', e);
+      }
+      try {
+        await markRefreshRotated(decoded.jti, ttl);
+      } catch {}
+      try {
+        await addToRevocationList(decoded.jti, 'refresh', 'revocation', ttl);
+      } catch (e) {
+        if (process.env.AUTH_TEST_LOGS) console.error('[revocation] addToRevocationList refresh failed', e);
+      }
+      try {
+        await deleteSession(decoded.jti);
+      } catch {}
+      try {
+        tokenRevokedCounter.inc({ type: 'refresh' });
+      } catch {}
+    }
+    return res.status(200).json({});
+  } catch (refreshErr) {
+    // ignore and try as access token
+  }
+
+  try {
+    const decoded: any = await verifyAccess(token);
+    if (decoded?.jti) {
+      const ttl = Math.max(ttlFromExp(decoded.exp), 1);
+      try {
+        await addToRevocationList(decoded.jti, 'access', 'revocation', ttl);
+      } catch (e) {
+        if (process.env.AUTH_TEST_LOGS) console.error('[revocation] addToRevocationList access failed', e);
+      }
+      try {
+        tokenRevokedCounter.inc({ type: 'access' });
+      } catch {}
+    }
+  } catch (accessErr) {
+    // Silently ignore invalid tokens per RFC 7009
+  }
+
+  return res.status(200).json({});
+}

--- a/apps/services/auth-service/internal/adapters/http/token.dto.ts
+++ b/apps/services/auth-service/internal/adapters/http/token.dto.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const pkcePattern = /^[A-Za-z0-9\-._~]+$/;
+
+export const TokenRequestSchema = z.object({
+  grant_type: z.union([z.literal('authorization_code'), z.literal('refresh_token')]),
+  code: z.string().optional(),
+  redirect_uri: z.string().url().optional(),
+  code_verifier: z
+    .string()
+    .min(43)
+    .max(128)
+    .regex(pkcePattern, 'code_verifier inválido')
+    .optional(),
+  client_id: z.string().optional(),
+  client_secret: z.string().optional(),
+  refresh_token: z.string().optional(),
+  scope: z.string().optional()
+});
+
+export type TokenRequest = z.infer<typeof TokenRequestSchema>;

--- a/apps/services/auth-service/internal/adapters/http/token.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/token.handler.ts
@@ -1,0 +1,189 @@
+import { createHash } from 'crypto';
+import { Request, Response } from 'express';
+import { TokenRequestSchema } from './token.dto';
+import {
+  clientSupportsGrant,
+  hasAllScopes,
+  normalizeScopes,
+  resolveClientAuthentication
+} from '../../oauth/clients';
+import { consumeAuthorizationCode } from '../redis/redis.adapter';
+import { issueTokenPair, rotateRefresh, signIdToken } from '../../security/jwt';
+import { getUserById } from '../db/pg.adapter';
+
+function base64Url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function verifyPkce(verifier: string, challenge: string, method: string): boolean {
+  const normalized = method.toUpperCase();
+  if (normalized === 'S256') {
+    const hashed = createHash('sha256').update(verifier).digest();
+    return base64Url(hashed) === challenge;
+  }
+  return verifier === challenge;
+}
+
+export async function tokenHandler(req: Request, res: Response) {
+  const parseResult = TokenRequestSchema.safeParse(req.body || {});
+  if (!parseResult.success) {
+    return res.status(400).json({ error: 'invalid_request', details: parseResult.error.flatten() });
+  }
+  const data = parseResult.data;
+  const authHeader = typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined;
+  const clientAuth = resolveClientAuthentication({
+    authorizationHeader: authHeader,
+    bodyClientId: data.client_id,
+    bodyClientSecret: data.client_secret
+  });
+  if (!clientAuth) {
+    return res.status(401).json({ error: 'invalid_client' });
+  }
+  const client = clientAuth.client;
+  if (!clientSupportsGrant(client, data.grant_type)) {
+    return res.status(400).json({ error: 'unsupported_grant_type' });
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+
+  if (data.grant_type === 'authorization_code') {
+    if (!data.code) {
+      return res.status(400).json({ error: 'invalid_request', error_description: 'code requerido' });
+    }
+    if (!data.redirect_uri) {
+      return res.status(400).json({ error: 'invalid_request', error_description: 'redirect_uri requerido' });
+    }
+    const stored = await consumeAuthorizationCode(data.code);
+    if (!stored || stored.clientId !== client.clientId) {
+      return res.status(400).json({ error: 'invalid_grant' });
+    }
+    if (stored.redirectUri !== data.redirect_uri) {
+      return res.status(400).json({ error: 'invalid_grant', error_description: 'redirect_uri no coincide' });
+    }
+    if (stored.codeChallenge) {
+      if (!data.code_verifier) {
+        return res.status(400).json({ error: 'invalid_grant', error_description: 'code_verifier requerido' });
+      }
+      const method = typeof stored.codeChallengeMethod === 'string' ? stored.codeChallengeMethod : 'plain';
+      if (!verifyPkce(data.code_verifier, stored.codeChallenge, method)) {
+        return res.status(400).json({ error: 'invalid_grant', error_description: 'PKCE inválido' });
+      }
+    }
+
+    const scopeString = typeof stored.scope === 'string' ? stored.scope : '';
+    const scopes = normalizeScopes(scopeString);
+    if (!hasAllScopes(client, scopes)) {
+      return res.status(400).json({ error: 'invalid_scope' });
+    }
+    const roles = Array.isArray(stored.roles)
+      ? stored.roles
+      : typeof stored.roles === 'string'
+      ? [stored.roles]
+      : [];
+    const tenantId = typeof stored.tenantId === 'string' ? stored.tenantId : 'default';
+
+    const pair = await issueTokenPair({
+      sub: stored.userId,
+      tenant_id: tenantId,
+      roles,
+      scope: scopeString,
+      client_id: client.clientId,
+      auth_time: typeof stored.authTime === 'number' ? stored.authTime : undefined
+    });
+
+    let idToken: string | null = null;
+    try {
+      const user = stored.userId ? await getUserById(stored.userId) : null;
+      const extra: Record<string, any> = {};
+      if (user) {
+        extra.email = user.email;
+        extra.name = user.name;
+      }
+      if (stored.nonce) extra.nonce = stored.nonce;
+      const id = await signIdToken({
+        sub: stored.userId,
+        tenant_id: tenantId,
+        client_id: client.clientId,
+        scope: scopeString,
+        roles,
+        auth_time: typeof stored.authTime === 'number' ? stored.authTime : undefined,
+        extra
+      });
+      idToken = id.token;
+    } catch (e) {
+      if (process.env.AUTH_TEST_LOGS) console.error('[token] error generando id_token', e);
+    }
+
+    const response: any = {
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: 'Bearer',
+      expires_in: pair.expiresIn,
+      scope: scopeString
+    };
+    if (idToken) response.id_token = idToken;
+    return res.json(response);
+  }
+
+  if (data.grant_type === 'refresh_token') {
+    if (!data.refresh_token) {
+      return res.status(400).json({ error: 'invalid_request', error_description: 'refresh_token requerido' });
+    }
+    const pair = await rotateRefresh(data.refresh_token);
+    if (!pair) {
+      return res.status(400).json({ error: 'invalid_grant' });
+    }
+    const currentScope = typeof pair.scope === 'string' ? pair.scope : '';
+    const grantedScopes = normalizeScopes(currentScope);
+    let scopeString = currentScope;
+    if (data.scope) {
+      const requestedScopes = normalizeScopes(data.scope);
+      if (!requestedScopes.every(scope => grantedScopes.includes(scope))) {
+        return res.status(400).json({ error: 'invalid_scope' });
+      }
+      scopeString = requestedScopes.join(' ');
+    }
+    const roles = Array.isArray(pair.roles)
+      ? pair.roles
+      : typeof pair.roles === 'string'
+      ? [pair.roles]
+      : [];
+    const tenantId = typeof pair.tenant_id === 'string' ? pair.tenant_id : typeof pair.tenantId === 'string' ? pair.tenantId : 'default';
+
+    let idToken: string | null = null;
+    if (scopeString.includes('openid')) {
+      try {
+        const user = pair.sub ? await getUserById(pair.sub) : null;
+        const extra: Record<string, any> = {};
+        if (user) {
+          extra.email = user.email;
+          extra.name = user.name;
+        }
+        const id = await signIdToken({
+          sub: pair.sub || '',
+          tenant_id: tenantId,
+          client_id: pair.client_id || client.clientId,
+          scope: scopeString,
+          roles,
+          extra
+        });
+        idToken = id.token;
+      } catch (e) {
+        if (process.env.AUTH_TEST_LOGS) console.error('[token] error generando id_token refresh', e);
+      }
+    }
+
+    const response: any = {
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: 'Bearer',
+      expires_in: pair.expiresIn,
+      scope: scopeString
+    };
+    if (idToken) response.id_token = idToken;
+    return res.json(response);
+  }
+
+  return res.status(400).json({ error: 'unsupported_grant_type' });
+}

--- a/apps/services/auth-service/internal/adapters/http/userinfo.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/userinfo.handler.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from 'express';
+import { verifyAccess } from '../../security/jwt';
+import { getUserById } from '../db/pg.adapter';
+import { normalizeScopes } from '../../oauth/clients';
+
+export async function userinfoHandler(req: Request, res: Response) {
+  const authorization = req.headers.authorization || req.headers.Authorization;
+  if (!authorization || typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'invalid_token' });
+  }
+  const token = authorization.slice('Bearer '.length).trim();
+  if (!token) {
+    return res.status(401).json({ error: 'invalid_token' });
+  }
+
+  let payload: any;
+  try {
+    payload = await verifyAccess(token);
+  } catch (e) {
+    return res.status(401).json({ error: 'invalid_token' });
+  }
+
+  if (!payload?.sub || typeof payload.sub !== 'string') {
+    return res.status(400).json({ error: 'invalid_token' });
+  }
+
+  const user = await getUserById(payload.sub);
+  if (!user) {
+    return res.status(404).json({ error: 'user_not_found' });
+  }
+
+  const scopeString = typeof payload.scope === 'string' ? payload.scope : '';
+  const scopes = normalizeScopes(scopeString);
+  const response: any = {
+    sub: payload.sub,
+    tenant_id: typeof payload.tenant_id === 'string' ? payload.tenant_id : 'default',
+    roles: Array.isArray(payload.roles)
+      ? payload.roles
+      : typeof payload.roles === 'string'
+      ? [payload.roles]
+      : [],
+    scope: scopeString || undefined
+  };
+
+  if (scopes.includes('profile')) {
+    response.name = user.name;
+  }
+  if (scopes.includes('email')) {
+    response.email = user.email;
+    response.email_verified = true;
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+  return res.json(response);
+}

--- a/apps/services/auth-service/internal/config/issuer.ts
+++ b/apps/services/auth-service/internal/config/issuer.ts
@@ -1,0 +1,60 @@
+const ISSUER_ENV_KEYS = [
+  'AUTH_ISSUER',
+  'AUTH_ISSUER_URL',
+  'AUTH_PUBLIC_URL',
+  'AUTH_BASE_URL'
+];
+
+function sanitize(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function ensureUrl(candidate: string): string | null {
+  if (!candidate) return null;
+  try {
+    const parsed = new URL(candidate);
+    const origin = `${parsed.protocol}//${parsed.host}`;
+    const path = parsed.pathname && parsed.pathname !== '/' ? parsed.pathname.replace(/\/+$/, '') : '';
+    return sanitize(origin + path);
+  } catch (e) {
+    const trimmed = candidate.trim();
+    if (!trimmed) return null;
+    const prefix = trimmed.startsWith('http://') || trimmed.startsWith('https://')
+      ? trimmed
+      : `https://${trimmed}`;
+    try {
+      const parsed = new URL(prefix);
+      const origin = `${parsed.protocol}//${parsed.host}`;
+      const path = parsed.pathname && parsed.pathname !== '/' ? parsed.pathname.replace(/\/+$/, '') : '';
+      return sanitize(origin + path);
+    } catch {
+      return sanitize(trimmed);
+    }
+  }
+}
+
+let cachedIssuer: string | null = null;
+
+export function getIssuer(): string {
+  if (cachedIssuer) return cachedIssuer;
+  for (const key of ISSUER_ENV_KEYS) {
+    const value = process.env[key];
+    const ensured = value ? ensureUrl(value) : null;
+    if (ensured) {
+      cachedIssuer = ensured;
+      return cachedIssuer;
+    }
+  }
+  const port = process.env.AUTH_PORT || '8080';
+  const host = process.env.AUTH_HOST || 'localhost';
+  const proto = process.env.AUTH_USE_TLS === 'true' ? 'https' : 'http';
+  cachedIssuer = `${proto}://${host.replace(/\/+$/, '')}:${port}`;
+  return cachedIssuer;
+}
+
+export function issuerUrl(path: string): string {
+  const base = getIssuer();
+  if (!path) return base;
+  if (/^https?:\/\//.test(path)) return sanitize(path);
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/apps/services/auth-service/internal/oauth/clients.ts
+++ b/apps/services/auth-service/internal/oauth/clients.ts
@@ -1,0 +1,237 @@
+import { z } from 'zod';
+
+export type TokenEndpointAuthMethod = 'none' | 'client_secret_basic' | 'client_secret_post';
+
+export interface OAuthClient {
+  clientId: string;
+  name: string;
+  redirectUris: string[];
+  grantTypes: string[];
+  responseTypes: string[];
+  allowedScopes: string[];
+  defaultScopes: string[];
+  requirePkce: boolean;
+  tokenEndpointAuthMethod: TokenEndpointAuthMethod;
+  clientSecret?: string;
+}
+
+const RawClientSchema = z.object({
+  client_id: z.string().min(1),
+  name: z.string().min(1).default('OAuth Client'),
+  redirect_uris: z.array(z.string().min(1)).min(1),
+  grant_types: z.array(z.string().min(1)).default(['authorization_code']),
+  response_types: z.array(z.string().min(1)).default(['code']),
+  scopes: z.array(z.string().min(1)).default(['openid']),
+  default_scopes: z.array(z.string().min(1)).optional(),
+  require_pkce: z.boolean().optional(),
+  token_endpoint_auth_method: z
+    .enum(['none', 'client_secret_basic', 'client_secret_post'])
+    .default('none'),
+  client_secret: z.string().optional()
+});
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function sanitizeRedirects(uris: string[]): string[] {
+  const valid: string[] = [];
+  for (const uri of uris) {
+    try {
+      // eslint-disable-next-line no-new
+      new URL(uri);
+      valid.push(uri);
+    } catch (e) {
+      if (process.env.AUTH_TEST_LOGS) {
+        console.warn('[oauth] redirect_uri inválida descartada', uri);
+      }
+    }
+  }
+  return unique(valid);
+}
+
+function parseEnvClients(): OAuthClient[] {
+  const raw = process.env.AUTH_OAUTH_CLIENTS;
+  if (!raw) return buildDefaultClients();
+  try {
+    const parsed = JSON.parse(raw);
+    const arr = Array.isArray(parsed) ? parsed : [parsed];
+    const clients: OAuthClient[] = [];
+    for (const item of arr) {
+      const result = RawClientSchema.safeParse(item);
+      if (!result.success) {
+        if (process.env.AUTH_TEST_LOGS) {
+          console.error('[oauth] configuración de cliente inválida', result.error.flatten());
+        }
+        continue;
+      }
+      const value = result.data;
+      const redirectUris = sanitizeRedirects(value.redirect_uris);
+      if (!redirectUris.length) continue;
+      clients.push({
+        clientId: value.client_id,
+        name: value.name,
+        redirectUris,
+        grantTypes: unique(value.grant_types),
+        responseTypes: unique(value.response_types),
+        allowedScopes: unique(value.scopes),
+        defaultScopes: unique(value.default_scopes && value.default_scopes.length ? value.default_scopes : value.scopes),
+        requirePkce: value.require_pkce !== false,
+        tokenEndpointAuthMethod: value.token_endpoint_auth_method,
+        clientSecret: value.client_secret
+      });
+    }
+    return clients.length ? clients : buildDefaultClients();
+  } catch (e) {
+    if (process.env.AUTH_TEST_LOGS) {
+      console.error('[oauth] AUTH_OAUTH_CLIENTS inválido. Usando defaults.', e);
+    }
+    return buildDefaultClients();
+  }
+}
+
+function buildDefaultClients(): OAuthClient[] {
+  const defaultRedirect = process.env.AUTH_DEFAULT_REDIRECT_URI || 'https://www.smart-edify.com/auth/callback';
+  const localRedirect = process.env.AUTH_LOCAL_REDIRECT_URI;
+  const redirects = sanitizeRedirects(unique([defaultRedirect, localRedirect].filter(Boolean) as string[]));
+  if (!redirects.length) {
+    redirects.push('https://www.smart-edify.com/auth/callback');
+  }
+  const baseScopes = process.env.AUTH_DEFAULT_SCOPES
+    ? unique(process.env.AUTH_DEFAULT_SCOPES.split(/\s+/))
+    : ['openid', 'profile', 'email', 'offline_access'];
+  return [
+    {
+      clientId: process.env.AUTH_DEFAULT_CLIENT_ID || 'squarespace',
+      name: 'Squarespace Portal',
+      redirectUris: redirects,
+      grantTypes: ['authorization_code', 'refresh_token'],
+      responseTypes: ['code'],
+      allowedScopes: baseScopes,
+      defaultScopes: baseScopes,
+      requirePkce: true,
+      tokenEndpointAuthMethod: 'none'
+    }
+  ];
+}
+
+const oauthClients = parseEnvClients();
+
+export function listOAuthClients(): OAuthClient[] {
+  return oauthClients;
+}
+
+export function findClientById(clientId: string | undefined | null): OAuthClient | undefined {
+  if (!clientId) return undefined;
+  return oauthClients.find(client => client.clientId === clientId);
+}
+
+export function clientSupportsGrant(client: OAuthClient, grantType: string): boolean {
+  return client.grantTypes.includes(grantType);
+}
+
+export function clientSupportsResponseType(client: OAuthClient, responseType: string): boolean {
+  return client.responseTypes.includes(responseType);
+}
+
+export function isRedirectUriAllowed(client: OAuthClient, redirectUri: string): boolean {
+  if (!redirectUri) return false;
+  try {
+    // eslint-disable-next-line no-new
+    new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  return client.redirectUris.includes(redirectUri);
+}
+
+export function normalizeScopes(scope?: string | string[] | null): string[] {
+  if (!scope) return [];
+  if (Array.isArray(scope)) return unique(scope.flatMap(s => s.split(/\s+/)).filter(Boolean));
+  return unique(scope.split(/\s+/).filter(Boolean));
+}
+
+export function hasAllScopes(client: OAuthClient, requested: string[]): boolean {
+  if (!requested.length) return true;
+  const allowed = new Set(client.allowedScopes);
+  return requested.every(scope => allowed.has(scope));
+}
+
+export function getDefaultScopes(client: OAuthClient): string[] {
+  return client.defaultScopes && client.defaultScopes.length ? client.defaultScopes : client.allowedScopes;
+}
+
+export function getSupportedScopes(): string[] {
+  const acc = new Set<string>();
+  for (const client of oauthClients) {
+    for (const scope of client.allowedScopes) {
+      acc.add(scope);
+    }
+  }
+  return Array.from(acc.values()).sort();
+}
+
+export function getTokenEndpointAuthMethods(): TokenEndpointAuthMethod[] {
+  return unique(oauthClients.map(c => c.tokenEndpointAuthMethod));
+}
+
+export interface ClientAuthenticationResult {
+  client: OAuthClient;
+  method: 'none' | 'basic' | 'post';
+}
+
+function parseBasicCredentials(authorization?: string | null): { clientId: string; clientSecret: string } | null {
+  if (!authorization || !authorization.startsWith('Basic ')) return null;
+  const encoded = authorization.slice('Basic '.length).trim();
+  if (!encoded) return null;
+  try {
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    const index = decoded.indexOf(':');
+    if (index === -1) return null;
+    return {
+      clientId: decoded.slice(0, index),
+      clientSecret: decoded.slice(index + 1)
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveClientAuthentication(options: {
+  authorizationHeader?: string;
+  bodyClientId?: string | null;
+  bodyClientSecret?: string | null;
+}): ClientAuthenticationResult | null {
+  const basic = parseBasicCredentials(options.authorizationHeader);
+  if (basic) {
+    const client = findClientById(basic.clientId);
+    if (!client) return null;
+    if (client.tokenEndpointAuthMethod === 'none') {
+      return null;
+    }
+    if (!client.clientSecret || client.clientSecret !== basic.clientSecret) {
+      return null;
+    }
+    return { client, method: 'basic' };
+  }
+
+  const clientId = options.bodyClientId || undefined;
+  const client = findClientById(clientId);
+  if (!client) return null;
+
+  switch (client.tokenEndpointAuthMethod) {
+    case 'client_secret_basic':
+      return null;
+    case 'client_secret_post':
+      if (!client.clientSecret || client.clientSecret !== (options.bodyClientSecret || '')) {
+        return null;
+      }
+      return { client, method: 'post' };
+    case 'none':
+    default:
+      if (client.clientSecret && options.bodyClientSecret && client.clientSecret !== options.bodyClientSecret) {
+        return null;
+      }
+      return { client, method: 'none' };
+  }
+}


### PR DESCRIPTION
## Summary
- implement OAuth client registry, issuer helpers, and PKCE authorization/token handlers that validate client_id, redirect_uri, scope, and grant_type
- add userinfo, introspection, revocation, and OpenID discovery handlers with new route wiring
- update OpenAPI spec and README with Authorization Code + PKCE flow details

## Testing
- npm run lint *(fails: ESLint config missing in repo)*
- npm run test *(fails: jest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c946365650832983d8f81314e898f0