### PR TITLE
Add MIT license and headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SmartEdify contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ SmartEdify es una plataforma modular orientada a servicios (Auth, Tenant, User, 
 - [SECURITY.md](SECURITY.md) — política de seguridad y divulgación responsable.
 - Directorios especializados: `docs/observability/`, `docs/design/`, `docs/security-hardening.md`, `docs/runbooks/`.
 
+## Licencia
+Este proyecto se distribuye bajo la licencia MIT. Consulta el archivo [LICENSE](LICENSE) para más detalles.
+
 ## Contribuciones
 1. Abre un issue o referencia una entrada en `docs/tareas.md` antes de iniciar trabajo.
 2. Sigue los linters y pruebas (`npm run lint`, `npm test`) en cada servicio modificado.

--- a/apps/services/auth-service/cmd/server/main.ts
+++ b/apps/services/auth-service/cmd/server/main.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024 SmartEdify contributors
+ * Licensed under the MIT License. See the LICENSE file in the project root for details.
+ */
+
 import 'dotenv/config';
 import { startTracing, shutdownTracing } from '../../internal/observability/tracing';
 import { context, trace } from '@opentelemetry/api';

--- a/apps/services/tenant-service/cmd/server/main.ts
+++ b/apps/services/tenant-service/cmd/server/main.ts
@@ -1,4 +1,7 @@
 /// <reference types="../..//types/fastify-di" />
+// Copyright (c) 2024 SmartEdify contributors
+// Licensed under the MIT License. See the LICENSE file in the project root for details.
+
 import Fastify from 'fastify';
 import { config } from '../../internal/config/env.js';
 import { pool } from '../../internal/adapters/repo/db.js';


### PR DESCRIPTION
## Summary
- add the MIT license file at the repository root
- reference the license in the main README and add headers to key service entrypoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9671330048329b17e4a1d54c08069