### PR TITLE
Add OpenAPI documentation and deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy API Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Swagger UI generator
+        run: npm install swagger-ui-dist@5 --no-save
+
+      - name: Prepare static site
+        run: |
+          mkdir -p public
+          cp -r node_modules/swagger-ui-dist/* public/
+          cp docs/api-reference/index.html public/index.html
+          cp docs/openapi.yaml public/openapi.yaml
+          touch public/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./public
+          commit_message: docs: deploy OpenAPI site

--- a/docs/api-reference/index.html
+++ b/docs/api-reference/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SmartEdify API Reference</title>
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      body {
+        margin: 0;
+        background: #0f172a;
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .swagger-ui {
+        max-width: 1080px;
+        margin: 0 auto;
+      }
+
+      .topbar,
+      .swagger-ui .topbar-wrapper {
+        display: none;
+      }
+
+      .info .title {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .info .title::before {
+        content: "";
+        display: inline-block;
+        width: 48px;
+        height: 48px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, #38bdf8 0%, #6366f1 100%);
+      }
+
+      .scheme-container {
+        box-shadow: none !important;
+      }
+
+      .opblock.opblock-post {
+        border-color: #22c55e;
+      }
+
+      .opblock.opblock-get {
+        border-color: #38bdf8;
+      }
+
+      .opblock.opblock-patch {
+        border-color: #f97316;
+      }
+
+      .opblock.opblock-delete {
+        border-color: #ef4444;
+      }
+
+      @media (max-width: 1024px) {
+        .swagger-ui {
+          padding: 0 1rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <noscript>
+      Necesitas habilitar JavaScript para visualizar la documentación interactiva.
+    </noscript>
+    <div id="swagger-ui"></div>
+    <script src="./swagger-ui-bundle.js" charset="UTF-8"></script>
+    <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+    <script>
+      window.onload = () => {
+        window.ui = SwaggerUIBundle({
+          url: "../openapi.yaml",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          docExpansion: "none",
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: "StandaloneLayout",
+          syntaxHighlight: {
+            activate: true,
+            theme: "obsidian",
+          },
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,706 @@
+openapi: 3.1.0
+info:
+  title: SmartEdify Public API
+  summary: API pública para gestionar catálogo de cursos, inscripciones y progreso académico.
+  version: 0.1.0
+  description: |
+    Esta especificación cubre los recursos fundamentales de SmartEdify para construir
+    integraciones personalizadas. Incluye endpoints para administrar cursos, lecciones,
+    usuarios inscritos y autenticación basada en tokens.
+  contact:
+    name: Plataforma SmartEdify
+    url: https://www.smartedify.com
+    email: developers@smartedify.com
+servers:
+  - url: https://api.smartedify.com/v1
+    description: Producción
+  - url: https://staging.api.smartedify.com/v1
+    description: Preproducción
+tags:
+  - name: Courses
+    description: Administración del catálogo de cursos y sus metadatos.
+  - name: Lessons
+    description: Gestión de lecciones dentro de un curso.
+  - name: Enrollments
+    description: Seguimiento del progreso y estado de los estudiantes en los cursos.
+  - name: Users
+    description: Operaciones relacionadas al perfil académico del usuario.
+  - name: Authentication
+    description: Flujos de autenticación y emisión de tokens.
+paths:
+  /courses:
+    get:
+      tags: [Courses]
+      summary: Listar cursos
+      description: Devuelve una lista paginada de cursos visibles para el consumidor.
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+        - name: category
+          in: query
+          description: Filtra por una categoría específica del catálogo.
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filtra por estado de publicación del curso.
+          schema:
+            type: string
+            enum: [draft, scheduled, published, archived]
+        - name: search
+          in: query
+          description: Texto libre para filtrar por título o descripción.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Colección de cursos recuperada correctamente.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Course'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    post:
+      tags: [Courses]
+      summary: Crear curso
+      description: Crea un nuevo curso dentro del catálogo.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourseCreate'
+      responses:
+        '201':
+          description: Curso creado exitosamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /courses/{courseId}:
+    parameters:
+      - $ref: '#/components/parameters/CourseId'
+    get:
+      tags: [Courses]
+      summary: Obtener curso
+      responses:
+        '200':
+          description: Curso encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Courses]
+      summary: Actualizar curso
+      description: Permite actualizar parcialmente los atributos del curso.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourseUpdate'
+      responses:
+        '200':
+          description: Curso actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Courses]
+      summary: Eliminar curso
+      description: Despublica un curso y lo remueve del catálogo activo.
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Curso eliminado.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /courses/{courseId}/lessons:
+    parameters:
+      - $ref: '#/components/parameters/CourseId'
+    get:
+      tags: [Lessons]
+      summary: Listar lecciones
+      description: Devuelve las lecciones ordenadas según el índice dentro del curso.
+      responses:
+        '200':
+          description: Lista de lecciones.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Lesson'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: [Lessons]
+      summary: Crear lección
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LessonCreate'
+      responses:
+        '201':
+          description: Lección creada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lesson'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /courses/{courseId}/lessons/{lessonId}:
+    parameters:
+      - $ref: '#/components/parameters/CourseId'
+      - $ref: '#/components/parameters/LessonId'
+    get:
+      tags: [Lessons]
+      summary: Obtener lección
+      responses:
+        '200':
+          description: Lección encontrada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lesson'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Lessons]
+      summary: Actualizar lección
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LessonUpdate'
+      responses:
+        '200':
+          description: Lección actualizada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lesson'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Lessons]
+      summary: Eliminar lección
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Lección eliminada.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /users/{userId}/enrollments:
+    parameters:
+      - $ref: '#/components/parameters/UserId'
+    get:
+      tags: [Enrollments]
+      summary: Listar inscripciones de un usuario
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Inscripciones del usuario.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Enrollment'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: [Enrollments]
+      summary: Inscribir usuario en curso
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentCreate'
+      responses:
+        '201':
+          description: Inscripción creada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Enrollment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /enrollments/{enrollmentId}:
+    parameters:
+      - $ref: '#/components/parameters/EnrollmentId'
+    patch:
+      tags: [Enrollments]
+      summary: Actualizar inscripción
+      description: Permite actualizar el estado o el progreso de una inscripción.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollmentUpdate'
+      responses:
+        '200':
+          description: Inscripción actualizada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Enrollment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /auth/token:
+    post:
+      tags: [Authentication]
+      summary: Obtener token de acceso
+      description: Autentica al usuario mediante email y contraseña para obtener tokens JWT.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
+      responses:
+        '200':
+          description: Token emitido correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    CourseId:
+      name: courseId
+      in: path
+      required: true
+      description: Identificador único del curso.
+      schema:
+        type: string
+        format: uuid
+    LessonId:
+      name: lessonId
+      in: path
+      required: true
+      description: Identificador único de la lección.
+      schema:
+        type: string
+        format: uuid
+    EnrollmentId:
+      name: enrollmentId
+      in: path
+      required: true
+      description: Identificador único de la inscripción.
+      schema:
+        type: string
+        format: uuid
+    UserId:
+      name: userId
+      in: path
+      required: true
+      description: Identificador único del usuario.
+      schema:
+        type: string
+        format: uuid
+    PageParam:
+      name: page
+      in: query
+      description: Número de página a recuperar.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PageSizeParam:
+      name: pageSize
+      in: query
+      description: Cantidad de elementos por página.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 20
+  responses:
+    BadRequest:
+      description: La solicitud no pudo procesarse por un error del cliente.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Autenticación requerida o token inválido.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: El recurso solicitado no se encuentra disponible.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+  schemas:
+    Course:
+      type: object
+      description: Representa un curso disponible en la plataforma.
+      properties:
+        id:
+          type: string
+          format: uuid
+        slug:
+          type: string
+          description: Identificador amigable para URLs.
+        title:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        difficulty:
+          type: string
+          enum: [beginner, intermediate, advanced]
+        status:
+          type: string
+          enum: [draft, scheduled, published, archived]
+        estimatedDuration:
+          type: integer
+          format: int32
+          description: Duración estimada en minutos.
+        featured:
+          type: boolean
+          default: false
+        coverImage:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required: [id, slug, title, status, createdAt, updatedAt]
+    CourseCreate:
+      type: object
+      required: [title, summary, description]
+      properties:
+        title:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        difficulty:
+          type: string
+          enum: [beginner, intermediate, advanced]
+        estimatedDuration:
+          type: integer
+          format: int32
+        featured:
+          type: boolean
+          default: false
+        coverImage:
+          type: string
+          format: uri
+        publishAt:
+          type: string
+          format: date-time
+          description: Fecha opcional de publicación programada.
+    CourseUpdate:
+      allOf:
+        - $ref: '#/components/schemas/CourseCreate'
+      description: Campos que pueden actualizarse de un curso existente.
+    Lesson:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        courseId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        order:
+          type: integer
+          minimum: 1
+        durationMinutes:
+          type: integer
+          minimum: 0
+        content:
+          type: string
+          description: Contenido enriquecido de la lección en formato Markdown.
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceLink'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required: [id, courseId, title, order, createdAt, updatedAt]
+    LessonCreate:
+      type: object
+      required: [title, order]
+      properties:
+        title:
+          type: string
+        order:
+          type: integer
+          minimum: 1
+        durationMinutes:
+          type: integer
+          minimum: 0
+        content:
+          type: string
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceLink'
+    LessonUpdate:
+      type: object
+      properties:
+        title:
+          type: string
+        order:
+          type: integer
+          minimum: 1
+        durationMinutes:
+          type: integer
+          minimum: 0
+        content:
+          type: string
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceLink'
+    ResourceLink:
+      type: object
+      description: Recursos descargables o enlaces de apoyo para una lección.
+      properties:
+        label:
+          type: string
+        url:
+          type: string
+          format: uri
+        contentType:
+          type: string
+          description: Tipo MIME del recurso.
+      required: [label, url]
+    Enrollment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        courseId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [invited, in_progress, completed, expired, cancelled]
+        progress:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        score:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+        certificateUrl:
+          type: string
+          format: uri
+        lastAccessedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required: [id, userId, courseId, status, progress, createdAt, updatedAt]
+    EnrollmentCreate:
+      type: object
+      required: [courseId]
+      properties:
+        courseId:
+          type: string
+          format: uuid
+        invitedBy:
+          type: string
+          format: uuid
+        initialStatus:
+          type: string
+          enum: [invited, in_progress]
+        expiresAt:
+          type: string
+          format: date-time
+    EnrollmentUpdate:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [invited, in_progress, completed, expired, cancelled]
+        progress:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        score:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+        completedAt:
+          type: string
+          format: date-time
+    TokenRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+        scope:
+          type: array
+          items:
+            type: string
+          description: Alcances solicitados para el token emitido.
+    TokenResponse:
+      type: object
+      properties:
+        tokenType:
+          type: string
+          enum: [Bearer]
+          default: Bearer
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        expiresIn:
+          type: integer
+          description: Tiempo de vida del token en segundos.
+      required: [tokenType, accessToken, expiresIn]
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        pageSize:
+          type: integer
+          minimum: 1
+        totalItems:
+          type: integer
+          minimum: 0
+        totalPages:
+          type: integer
+          minimum: 0
+      required: [page, pageSize, totalItems, totalPages]
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
+      required: [code, message]


### PR DESCRIPTION
## Summary
- add a SmartEdify public API OpenAPI specification for courses, lessons, enrollments, and authentication
- bundle a Swagger UI driven static site in `docs/api-reference` that renders the new `docs/openapi.yaml`
- configure a `deploy-docs.yml` GitHub Action to build the site with `swagger-ui-dist` assets and push it to `gh-pages`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c968436dc48329883bb7cc46e6075d