### PR TITLE
Fix Swagger UI spec path for GitHub Pages

### DIFF
--- a/docs/api-reference/index.html
+++ b/docs/api-reference/index.html
@@ -80,8 +80,13 @@
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"></script>
     <script>
       window.onload = () => {
+        const currentPath = window.location.pathname;
+        const specUrl = currentPath.includes("/api-reference/")
+          ? "../openapi.yaml"
+          : "openapi.yaml";
+
         window.ui = SwaggerUIBundle({
-          url: "../openapi.yaml",
+          url: specUrl,
           dom_id: "#swagger-ui",
           deepLinking: true,
           docExpansion: "none",


### PR DESCRIPTION
## Summary
- ensure the Swagger UI page can locate the OpenAPI specification both locally and once published to GitHub Pages by deriving the spec URL from the current path

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c96aee7be08329acdbcfda015d91e2