### PR TITLE
Add OpenTelemetry collector and Prometheus configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ SmartEdify es una plataforma modular orientada a servicios (Auth, Tenant, User, 
   ```
   Consulta [docs/docker.md](docs/docker.md#stack-local-persistencia-y-servicios) para detalles de puertos, variables de entorno y el script `scripts/dev-up.ps1` que automatiza healthchecks y migraciones.
 
+### Observabilidad local (OpenTelemetry + Prometheus)
+- Para habilitar la recolección de métricas y trazas ejecuta:
+  ```sh
+  docker compose up -d otel-collector prometheus
+  ```
+- Endpoints expuestos por el collector (puertos configurables mediante variables de entorno):
+  - OTLP gRPC: `localhost:${OTEL_COLLECTOR_GRPC_PORT:-4317}`.
+  - OTLP HTTP para traces: `http://localhost:${OTEL_COLLECTOR_HTTP_PORT:-4318}/v1/traces`.
+  - OTLP HTTP para métricas: `http://localhost:${OTEL_COLLECTOR_HTTP_PORT:-4318}/v1/metrics`.
+  - Métricas Prometheus: `http://localhost:${OTEL_COLLECTOR_PROM_PORT:-8889}/metrics`.
+- Interfaz de Prometheus para explorar series: `http://localhost:${PROMETHEUS_PORT:-9090}`.
+
 ### Ejecutar servicios
 - Auth Service:
   ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,32 @@ services:
       - "${USER_PORT:-9081}:8081"
     restart: unless-stopped
 
+  otel-collector:
+    image: otel/opentelemetry-collector:0.88.0
+    container_name: otel-collector
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./observability/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "${OTEL_COLLECTOR_GRPC_PORT:-4317}:4317"
+      - "${OTEL_COLLECTOR_HTTP_PORT:-4318}:4318"
+      - "${OTEL_COLLECTOR_PROM_PORT:-8889}:8889"
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    depends_on:
+      otel-collector:
+        condition: service_started
+    restart: unless-stopped
+
 volumes:
   redis_data:
   db_data:

--- a/observability/otel-collector-config.yaml
+++ b/observability/otel-collector-config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+exporters:
+  logging:
+    loglevel: info
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    metric_expiration: 5m
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, logging]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8889']


### PR DESCRIPTION
## Summary
- add OpenTelemetry Collector configuration and Prometheus scrape definition for local observability
- extend docker-compose stack with collector and Prometheus services exposing OTLP and metrics endpoints
- document how to start the observability stack and the relevant metrics and traces endpoints

## Testing
- docker compose config *(fails: docker not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68c96decd1ec83298387ed5414bd5a4a