### PR TITLE
Add RabbitMQ DLQ topology and monitoring

### DIFF
--- a/apps/services/tenant-service/cmd/server/main.ts
+++ b/apps/services/tenant-service/cmd/server/main.ts
@@ -24,6 +24,8 @@ import { LoggingPublisher } from '../../internal/adapters/publisher/publisher.js
 import { KafkaPublisher } from '../../internal/adapters/publisher/kafka-publisher.js';
 import { LoggingConsumer } from '../../internal/adapters/consumer/consumer.js';
 import { KafkaLagConsumer } from '../../internal/adapters/consumer/kafka-consumer.js';
+import { RabbitMqPublisher } from '../../internal/adapters/publisher/rabbitmq-publisher.js';
+import { RabbitMqDeadLetterConsumer } from '../../internal/adapters/consumer/rabbitmq-dead-letter-consumer.js';
 import { authJwtPlugin } from '../../internal/adapters/http/plugins/auth-jwt.js';
 import { startTracing, shutdownTracing } from '../../internal/observability/tracing.js';
 import { JwksProvider } from '../../internal/adapters/security/jwks-provider.js';
@@ -61,10 +63,24 @@ async function build() {
       logger: app.log
     });
     app.log.info({ brokers: config.kafkaBrokers }, 'KafkaPublisher enabled');
+  } else if (config.publisherKind === 'rabbitmq') {
+    publisher = new RabbitMqPublisher({
+      url: config.rabbitUrl,
+      exchange: config.rabbitExchange,
+      routingKey: config.rabbitRoutingKey,
+      queue: config.rabbitQueue,
+      deadLetterExchange: config.rabbitDeadLetterExchange,
+      deadLetterQueue: config.rabbitDeadLetterQueue,
+      deadLetterRoutingKey: config.rabbitDeadLetterRoutingKey,
+      logger: app.log
+    });
+    app.log.info({ exchange: config.rabbitExchange, queue: config.rabbitQueue }, 'RabbitMqPublisher enabled');
   } else {
     publisher = new LoggingPublisher(app.log);
     if (config.publisherKind === 'kafka') {
       app.log.warn('Kafka requested but no brokers configured, falling back to LoggingPublisher');
+    } else if (config.publisherKind === 'rabbitmq') {
+      app.log.warn('RabbitMQ requested but no configuration provided, falling back to LoggingPublisher');
     }
   }
   const poller = new OutboxPoller(di.outboxRepo, publisher, { intervalMs: config.outboxPollIntervalMs, batchSize: config.outboxBatchSize, logger: app.log });
@@ -82,7 +98,21 @@ async function build() {
       lagIntervalMs: config.kafkaConsumerLagIntervalMs,
       logger: app.log
     });
-  consumer.start().catch((e: any) => app.log.error(e, 'consumer start failed'));
+    consumer.start().catch((e: any) => app.log.error(e, 'consumer start failed'));
+  } else if (config.consumerKind === 'rabbitmq') {
+    consumer = new RabbitMqDeadLetterConsumer({
+      url: config.rabbitUrl,
+      exchange: config.rabbitExchange,
+      routingKey: config.rabbitRoutingKey,
+      queue: config.rabbitQueue,
+      deadLetterExchange: config.rabbitDeadLetterExchange,
+      deadLetterQueue: config.rabbitDeadLetterQueue,
+      deadLetterRoutingKey: config.rabbitDeadLetterRoutingKey,
+      checkIntervalMs: config.rabbitDeadLetterCheckIntervalMs,
+      alertThreshold: config.rabbitDeadLetterAlertThreshold,
+      logger: app.log
+    });
+    consumer.start().catch((e: any) => app.log.error(e, 'rabbitmq dead-letter consumer failed'));
   } else if (config.consumerKind === 'logging') {
     consumer = new LoggingConsumer();
     await consumer.start();

--- a/apps/services/tenant-service/internal/adapters/consumer/rabbitmq-dead-letter-consumer.ts
+++ b/apps/services/tenant-service/internal/adapters/consumer/rabbitmq-dead-letter-consumer.ts
@@ -1,0 +1,98 @@
+import type { Channel, Connection } from 'amqplib';
+import { loadAmqpModule } from '../messaging/amqp-loader.js';
+import { ensureRabbitMqTopology } from '../messaging/rabbitmq-topology.js';
+import { Consumer } from './consumer.js';
+import { brokerDeadLetterMessagesGauge } from '../../metrics/registry.js';
+
+export interface RabbitMqDeadLetterConsumerOptions {
+  url: string;
+  exchange: string;
+  routingKey: string;
+  queue: string;
+  deadLetterExchange: string;
+  deadLetterQueue: string;
+  deadLetterRoutingKey?: string;
+  checkIntervalMs: number;
+  alertThreshold?: number;
+  logger?: any;
+}
+
+export class RabbitMqDeadLetterConsumer implements Consumer {
+  private connection: Connection | null = null;
+  private channel: Channel | null = null;
+  private timer: NodeJS.Timeout | null = null;
+  private started = false;
+  private shuttingDown = false;
+  private lastAlertCount = 0;
+
+  constructor(private opts: RabbitMqDeadLetterConsumerOptions) {}
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    try {
+      const amqp = await loadAmqpModule();
+      this.connection = await amqp.connect(this.opts.url);
+      this.connection.on('error', err => {
+        this.opts.logger?.error({ err }, 'rabbitmq dead-letter connection error');
+      });
+      this.connection.on('close', () => {
+        this.opts.logger?.warn('rabbitmq dead-letter connection closed');
+        this.channel = null;
+        brokerDeadLetterMessagesGauge.set(0);
+      });
+      this.channel = await this.connection.createChannel();
+      await ensureRabbitMqTopology(this.channel, {
+        exchange: this.opts.exchange,
+        routingKey: this.opts.routingKey,
+        queue: this.opts.queue,
+        deadLetterExchange: this.opts.deadLetterExchange,
+        deadLetterQueue: this.opts.deadLetterQueue,
+        deadLetterRoutingKey: this.opts.deadLetterRoutingKey
+      }, this.opts.logger);
+      await this.pollOnce();
+      this.timer = setInterval(() => {
+        this.pollOnce().catch(err => {
+          this.opts.logger?.error({ err }, 'rabbitmq dead-letter monitor error');
+        });
+      }, this.opts.checkIntervalMs);
+    } catch (err) {
+      this.started = false;
+      brokerDeadLetterMessagesGauge.set(0);
+      this.opts.logger?.error({ err }, 'rabbitmq dead-letter consumer start failed');
+      await this.shutdown().catch(() => {});
+      throw err;
+    }
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (!this.channel) return;
+    const info = await this.channel.checkQueue(this.opts.deadLetterQueue);
+    const count = info?.messageCount ?? 0;
+    brokerDeadLetterMessagesGauge.set(count);
+    const threshold = this.opts.alertThreshold ?? 1;
+    if (count >= threshold && count !== this.lastAlertCount) {
+      this.opts.logger?.warn({ queue: this.opts.deadLetterQueue, count }, 'messages accumulated in dead-letter queue');
+      this.lastAlertCount = count;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.channel) {
+      try { await this.channel.close(); } catch { /* ignore */ }
+      this.channel = null;
+    }
+    if (this.connection) {
+      try { await this.connection.close(); } catch { /* ignore */ }
+      this.connection = null;
+    }
+    this.started = false;
+    this.shuttingDown = false;
+  }
+}

--- a/apps/services/tenant-service/internal/adapters/messaging/amqp-loader.ts
+++ b/apps/services/tenant-service/internal/adapters/messaging/amqp-loader.ts
@@ -1,0 +1,13 @@
+let amqpModulePromise: Promise<typeof import('amqplib')> | null = null;
+
+export async function loadAmqpModule() {
+  if (!amqpModulePromise) {
+    amqpModulePromise = import('amqplib').catch(err => {
+      amqpModulePromise = null;
+      const error = new Error('amqplib module not found. Install it with "npm install amqplib".');
+      (error as any).cause = err;
+      throw error;
+    });
+  }
+  return amqpModulePromise;
+}

--- a/apps/services/tenant-service/internal/adapters/messaging/rabbitmq-topology.ts
+++ b/apps/services/tenant-service/internal/adapters/messaging/rabbitmq-topology.ts
@@ -1,0 +1,38 @@
+import type { Channel } from 'amqplib';
+
+export interface RabbitMqTopologyOptions {
+  exchange: string;
+  routingKey: string;
+  queue: string;
+  deadLetterExchange: string;
+  deadLetterQueue: string;
+  deadLetterRoutingKey?: string;
+}
+
+export async function ensureRabbitMqTopology(channel: Channel, opts: RabbitMqTopologyOptions, logger?: any): Promise<void> {
+  const {
+    exchange,
+    routingKey,
+    queue,
+    deadLetterExchange,
+    deadLetterQueue,
+    deadLetterRoutingKey
+  } = opts;
+
+  await channel.assertExchange(deadLetterExchange, 'topic', { durable: true });
+  await channel.assertQueue(deadLetterQueue, { durable: true });
+  const bindingKey = deadLetterRoutingKey ?? routingKey ?? '';
+  await channel.bindQueue(deadLetterQueue, deadLetterExchange, bindingKey);
+
+  await channel.assertExchange(exchange, 'topic', { durable: true });
+  const args: Record<string, any> = { 'x-dead-letter-exchange': deadLetterExchange };
+  if (deadLetterRoutingKey) {
+    args['x-dead-letter-routing-key'] = deadLetterRoutingKey;
+  }
+  await channel.assertQueue(queue, {
+    durable: true,
+    arguments: args
+  });
+  await channel.bindQueue(queue, exchange, routingKey);
+  logger?.debug?.({ exchange, queue, deadLetterExchange, deadLetterQueue }, 'rabbitmq topology ensured');
+}

--- a/apps/services/tenant-service/internal/adapters/publisher/rabbitmq-publisher.ts
+++ b/apps/services/tenant-service/internal/adapters/publisher/rabbitmq-publisher.ts
@@ -1,0 +1,134 @@
+import { ensureRabbitMqTopology } from '../messaging/rabbitmq-topology.js';
+import { loadAmqpModule } from '../messaging/amqp-loader.js';
+import type { Connection, ConfirmChannel } from 'amqplib';
+import type { OutboxEnvelope } from './publisher.js';
+import { Publisher, PublisherResult } from './publisher.js';
+import { brokerPayloadBytesTotal, brokerPublishLatency, brokerPublisherConnectFailTotal, brokerPublisherHealthGauge } from '../../metrics/registry.js';
+
+export interface RabbitMqPublisherOptions {
+  url: string;
+  exchange: string;
+  routingKey: string;
+  queue: string;
+  deadLetterExchange: string;
+  deadLetterQueue: string;
+  deadLetterRoutingKey?: string;
+  logger?: any;
+}
+
+export class RabbitMqPublisher implements Publisher {
+  private connection: Connection | null = null;
+  private channel: ConfirmChannel | null = null;
+  private connecting: Promise<void> | null = null;
+  private shuttingDown = false;
+
+  constructor(private opts: RabbitMqPublisherOptions) {
+    brokerPublisherHealthGauge.set(0);
+  }
+
+  private async ensureConnection() {
+    if (this.channel || this.shuttingDown) return;
+    if (this.connecting) {
+      await this.connecting;
+      return;
+    }
+    this.connecting = (async () => {
+      const amqp = await loadAmqpModule();
+      try {
+        this.connection = await amqp.connect(this.opts.url);
+        this.connection.on('close', () => {
+          this.channel = null;
+          this.connection = null;
+          brokerPublisherHealthGauge.set(0);
+        });
+        this.connection.on('error', (err: any) => {
+          this.opts.logger?.error({ err }, 'rabbitmq connection error');
+        });
+        this.channel = await this.connection.createConfirmChannel();
+        await ensureRabbitMqTopology(this.channel, {
+          exchange: this.opts.exchange,
+          routingKey: this.opts.routingKey,
+          queue: this.opts.queue,
+          deadLetterExchange: this.opts.deadLetterExchange,
+          deadLetterQueue: this.opts.deadLetterQueue,
+          deadLetterRoutingKey: this.opts.deadLetterRoutingKey
+        }, this.opts.logger);
+        brokerPublisherHealthGauge.set(1);
+      } catch (err) {
+        brokerPublisherHealthGauge.set(0);
+        brokerPublisherConnectFailTotal.inc();
+        this.opts.logger?.error({ err }, 'rabbitmq publisher connection failed');
+        await this.teardown();
+        throw err;
+      }
+    })();
+    try {
+      await this.connecting;
+    } finally {
+      this.connecting = null;
+    }
+  }
+
+  private async teardown() {
+    if (this.channel) {
+      try { await this.channel.close(); } catch { /* ignore */ }
+      this.channel = null;
+    }
+    if (this.connection) {
+      try { await this.connection.close(); } catch { /* ignore */ }
+      this.connection = null;
+    }
+    brokerPublisherHealthGauge.set(0);
+  }
+
+  async publish(ev: OutboxEnvelope): Promise<PublisherResult> {
+    if (this.shuttingDown) {
+      return { ok: false, error: new Error('publisher is shutting down') };
+    }
+    try {
+      await this.ensureConnection();
+    } catch (err) {
+      return { ok: false, error: err };
+    }
+    if (!this.channel) {
+      return { ok: false, error: new Error('rabbitmq channel unavailable') };
+    }
+    const payload = Buffer.from(JSON.stringify(ev));
+    const start = process.hrtime.bigint();
+    try {
+      const published = this.channel.publish(this.opts.exchange, this.opts.routingKey, payload, {
+        persistent: true,
+        contentType: 'application/json',
+        headers: {
+          'x-event-type': ev.type,
+          'x-event-id': ev.id,
+          'x-aggregate-id': ev.aggregateId
+        }
+      });
+      if (!published) {
+        await new Promise(resolve => this.channel?.once('drain', resolve));
+      }
+      await this.channel.waitForConfirms();
+      const end = process.hrtime.bigint();
+      const seconds = Number(end - start) / 1e9;
+      brokerPublishLatency.observe(seconds);
+      brokerPayloadBytesTotal.inc(payload.length);
+      return { ok: true };
+    } catch (err) {
+      this.opts.logger?.error({ err }, 'rabbitmq publish failed');
+      brokerPublisherHealthGauge.set(0);
+      await this.teardown();
+      return { ok: false, error: err };
+    }
+  }
+
+  async health(): Promise<{ ok: boolean; details?: any }> {
+    const ok = !!this.connection && !!this.channel;
+    return { ok, details: { queue: this.opts.queue, exchange: this.opts.exchange } };
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    await this.teardown();
+  }
+}

--- a/apps/services/tenant-service/internal/config/env.ts
+++ b/apps/services/tenant-service/internal/config/env.ts
@@ -9,18 +9,27 @@ export interface TenantConfig {
   contextCacheTtlMs: number;
   jwksUrl?: string;
   jwksCacheTtlMs: number;
-  publisherKind: 'logging' | 'kafka';
+  publisherKind: 'logging' | 'kafka' | 'rabbitmq';
   kafkaBrokers: string[];
   kafkaClientId: string;
   kafkaTopicPrefix: string;
   kafkaAcks: number;
   outboxMaxPayloadBytes: number; // límite de validación de payload serializado
-  consumerKind: 'none' | 'logging' | 'kafka';
+  consumerKind: 'none' | 'logging' | 'kafka' | 'rabbitmq';
   kafkaConsumerGroupId: string;
   kafkaConsumerLagIntervalMs: number;
   consumerMaxRetries: number;
   consumerRetryBaseDelayMs: number;
   consumerRetryMaxDelayMs: number;
+  rabbitUrl: string;
+  rabbitExchange: string;
+  rabbitRoutingKey: string;
+  rabbitQueue: string;
+  rabbitDeadLetterExchange: string;
+  rabbitDeadLetterQueue: string;
+  rabbitDeadLetterRoutingKey?: string;
+  rabbitDeadLetterCheckIntervalMs: number;
+  rabbitDeadLetterAlertThreshold: number;
 }
 
 function required(name: string, value: string | undefined): string {
@@ -37,16 +46,25 @@ export const config: TenantConfig = {
   contextCacheTtlMs: parseInt(process.env.TENANT_CONTEXT_CACHE_TTL_MS || '60000', 10)
   ,jwksUrl: process.env.TENANT_JWKS_URL,
   jwksCacheTtlMs: parseInt(process.env.TENANT_JWKS_CACHE_TTL_MS || '600000', 10),
-  publisherKind: (process.env.TENANT_PUBLISHER || 'logging') as 'logging' | 'kafka',
+  publisherKind: (process.env.TENANT_PUBLISHER || 'logging') as 'logging' | 'kafka' | 'rabbitmq',
   kafkaBrokers: (process.env.KAFKA_BROKERS || '').split(',').filter(Boolean),
   kafkaClientId: process.env.KAFKA_CLIENT_ID || 'tenant-service',
   kafkaTopicPrefix: process.env.KAFKA_TOPIC_PREFIX || 'tenant',
   kafkaAcks: parseInt(process.env.KAFKA_ACKS || '-1', 10),
   outboxMaxPayloadBytes: parseInt(process.env.OUTBOX_MAX_PAYLOAD_BYTES || '65536', 10),
-  consumerKind: (process.env.TENANT_CONSUMER || 'none') as 'none' | 'logging' | 'kafka',
+  consumerKind: (process.env.TENANT_CONSUMER || 'none') as 'none' | 'logging' | 'kafka' | 'rabbitmq',
   kafkaConsumerGroupId: process.env.KAFKA_CONSUMER_GROUP_ID || 'tenant-service-consumer',
   kafkaConsumerLagIntervalMs: parseInt(process.env.KAFKA_CONSUMER_LAG_INTERVAL_MS || '10000', 10)
   ,consumerMaxRetries: parseInt(process.env.CONSUMER_MAX_RETRIES || '5', 10)
   ,consumerRetryBaseDelayMs: parseInt(process.env.CONSUMER_RETRY_BASE_DELAY_MS || '100', 10)
   ,consumerRetryMaxDelayMs: parseInt(process.env.CONSUMER_RETRY_MAX_DELAY_MS || '2000', 10)
+  ,rabbitUrl: process.env.RABBITMQ_URL || 'amqp://guest:guest@rabbitmq:5672'
+  ,rabbitExchange: process.env.RABBITMQ_EXCHANGE || 'tenant.events'
+  ,rabbitRoutingKey: process.env.RABBITMQ_ROUTING_KEY || 'tenant.event'
+  ,rabbitQueue: process.env.RABBITMQ_QUEUE || 'tenant-events'
+  ,rabbitDeadLetterExchange: process.env.RABBITMQ_DLX || 'dlx'
+  ,rabbitDeadLetterQueue: process.env.RABBITMQ_DEAD_LETTER_QUEUE || 'dead-letter'
+  ,rabbitDeadLetterRoutingKey: process.env.RABBITMQ_DEAD_LETTER_ROUTING_KEY || undefined
+  ,rabbitDeadLetterCheckIntervalMs: parseInt(process.env.RABBITMQ_DLQ_CHECK_INTERVAL_MS || '30000', 10)
+  ,rabbitDeadLetterAlertThreshold: parseInt(process.env.RABBITMQ_DLQ_ALERT_THRESHOLD || '1', 10)
 };

--- a/apps/services/tenant-service/internal/metrics/registry.ts
+++ b/apps/services/tenant-service/internal/metrics/registry.ts
@@ -102,6 +102,10 @@ export const brokerPublisherConnectFailTotal = new client.Counter({
   name: 'broker_publisher_connect_fail_total',
   help: 'Fallos al intentar conectar el publisher (inicio diferido)'
 });
+export const brokerDeadLetterMessagesGauge = new client.Gauge({
+  name: 'broker_dead_letter_messages',
+  help: 'Mensajes acumulados en la cola dead-letter del broker'
+});
 
 // Consumer lag
 export const brokerConsumerLagGauge = new client.Gauge({
@@ -174,6 +178,7 @@ registry.registerMetric(brokerPayloadBytesTotal);
 registry.registerMetric(outboxValidationFailedTotal);
 registry.registerMetric(brokerPublisherHealthGauge);
 registry.registerMetric(brokerPublisherConnectFailTotal);
+registry.registerMetric(brokerDeadLetterMessagesGauge);
 registry.registerMetric(brokerConsumerLagGauge);
 registry.registerMetric(brokerConsumerLagMaxGauge);
 registry.registerMetric(brokerConsumerLagPollFailedTotal);

--- a/apps/services/tenant-service/types/amqplib.d.ts
+++ b/apps/services/tenant-service/types/amqplib.d.ts
@@ -1,0 +1,27 @@
+declare module 'amqplib' {
+  export interface Replies {
+    assertQueue: { queue: string; messageCount: number; consumerCount: number };
+  }
+
+  export interface Channel {
+    assertQueue(queue: string, options?: any): Promise<Replies['assertQueue']>;
+    assertExchange(exchange: string, type: string, options?: any): Promise<any>;
+    bindQueue(queue: string, exchange: string, pattern: string, args?: any): Promise<void>;
+    publish(exchange: string, routingKey: string, content: Buffer, options?: any): boolean;
+    waitForConfirms(): Promise<void>;
+    close(): Promise<void>;
+    checkQueue(queue: string): Promise<Replies['assertQueue']>;
+    prefetch(count: number): Promise<void>;
+  }
+
+  export interface ConfirmChannel extends Channel {}
+
+  export interface Connection {
+    createChannel(): Promise<Channel>;
+    createConfirmChannel(): Promise<ConfirmChannel>;
+    close(): Promise<void>;
+    on(event: string, listener: (...args: any[]) => void): this;
+  }
+
+  export function connect(url: string): Promise<Connection>;
+}

--- a/docs/operations/rabbitmq-dead-letter.md
+++ b/docs/operations/rabbitmq-dead-letter.md
@@ -1,0 +1,55 @@
+# Topología RabbitMQ y Dead Letter Queue
+
+Este documento describe la configuración base de RabbitMQ empleada por los servicios de backend para publicar eventos a través de la outbox y gestionar mensajes en la cola *dead-letter* (DLQ). Se detalla el flujo de mensajes, las políticas de reintento y las responsabilidades operativas asociadas.
+
+## Topología
+
+| Recurso | Nombre por defecto | Descripción |
+|---------|--------------------|-------------|
+| Exchange principal | `tenant.events` (`RABBITMQ_EXCHANGE`) | Exchange de tipo `topic` que recibe los eventos publicados por la outbox. |
+| Cola principal | `tenant-events` (`RABBITMQ_QUEUE`) | Cola duradera a la que se enrutan los mensajes salientes. |
+| Exchange DLX | `dlx` (`RABBITMQ_DLX`) | Exchange dedicado a los mensajes que no pudieron procesarse exitosamente. |
+| Cola dead-letter | `dead-letter` (`RABBITMQ_DEAD_LETTER_QUEUE`) | Cola duradera que almacena los mensajes fallidos. |
+
+La cola principal se declara con los argumentos `x-dead-letter-exchange` y, opcionalmente, `x-dead-letter-routing-key`. Esto garantiza que cualquier `nack`, expiración o error de procesamiento moverá el mensaje al exchange `dlx`, que a su vez lo enruta a la cola `dead-letter`.
+
+## Flujo de mensajes
+
+1. El *Outbox Poller* serializa el evento y lo envía al `RabbitMqPublisher`.
+2. El publisher garantiza la topología anterior (exchanges + colas) y publica en `tenant.events` con `routingKey` configurable (`RABBITMQ_ROUTING_KEY`).
+3. Los consumidores principales (futuros workers) extraen mensajes de `tenant-events` y confirman con `ack` cuando el procesamiento es exitoso.
+4. Ante un `nack` o al superar los reintentos configurados en la capa de dominio, el mensaje se redirige automáticamente al exchange `dlx` y termina en la cola `dead-letter`.
+
+## Políticas de reintento
+
+- La capa de outbox realiza reintentos en memoria antes de publicar, con *backoff* exponencial (`CONSUMER_RETRY_BASE_DELAY_MS`, `CONSUMER_RETRY_MAX_DELAY_MS`).
+- El publisher marca cada mensaje como persistente para permitir reentregas posteriores en RabbitMQ.
+- Los consumidores deben aplicar reintentos idempotentes y emitir `nack` sólo cuando el error sea permanente. Los errores transitorios se reintentan según la estrategia interna del consumidor.
+- El `RabbitMqDeadLetterConsumer` no reenvía automáticamente los mensajes, pero genera visibilidad operativa sobre la cola DLQ.
+
+## Monitorización y alertas
+
+- Métrica `broker_dead_letter_messages`: gauge Prometheus que refleja el número de mensajes en la cola `dead-letter`. Se actualiza periódicamente (intervalo `RABBITMQ_DLQ_CHECK_INTERVAL_MS`).
+- Logs: cada vez que el monitor detecta nuevos mensajes en la DLQ se emite un `warn` con el tamaño de la cola.
+- Alertas sugeridas: disparar un aviso si la métrica supera `RABBITMQ_DLQ_ALERT_THRESHOLD` durante más de 5 minutos o si la cola crece de forma sostenida.
+
+## Operaciones de reintento manual
+
+1. Revisar métricas y logs para identificar la causa raíz del fallo.
+2. Inspeccionar los mensajes con `rabbitmqadmin get queue=dead-letter count=10` (no olvidar confirmar/descartar tras la revisión).
+3. Una vez corregido el problema, reenviar los mensajes usando `rabbitmqadmin publish exchange=tenant.events routing_key=<routing> payload="..."` o scripts específicos.
+4. Documentar el incidente y la resolución en el runbook correspondiente.
+
+## Variables de configuración relevantes
+
+| Variable | Descripción |
+|----------|-------------|
+| `TENANT_PUBLISHER=rabbitmq` | Activa el publisher RabbitMQ. |
+| `TENANT_CONSUMER=rabbitmq` | Habilita el monitor de DLQ para RabbitMQ. |
+| `RABBITMQ_URL` | Cadena de conexión AMQP (incluye credenciales/host/puerto). |
+| `RABBITMQ_EXCHANGE`, `RABBITMQ_ROUTING_KEY`, `RABBITMQ_QUEUE` | Configuración de la cola principal. |
+| `RABBITMQ_DLX`, `RABBITMQ_DEAD_LETTER_QUEUE`, `RABBITMQ_DEAD_LETTER_ROUTING_KEY` | Topología de la cola dead-letter. |
+| `RABBITMQ_DLQ_CHECK_INTERVAL_MS` | Frecuencia de muestreo de la cola dead-letter. |
+| `RABBITMQ_DLQ_ALERT_THRESHOLD` | Número de mensajes a partir del cual se emite alerta en logs/métricas. |
+
+> Nota: para ambientes donde RabbitMQ no está disponible, el monitor/publisher registrarán el error y permanecerán en modo inactivo. Instalar `amqplib` es requisito para habilitar la funcionalidad completa.


### PR DESCRIPTION
## Summary
- add RabbitMQ publisher and DLQ monitor that ensure exchanges, queues and metrics are created
- extend tenant service config to support RabbitMQ settings and expose DLQ metrics
- document the RabbitMQ message flow, retry policy and operational guidance

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js; dependencies unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9735233808329924fb32a8a6a34aa