### PR TITLE
Add secret scanning gate to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,32 @@ jobs:
         run: npm run lint
         working-directory: apps/services/${{ matrix.service }}
 
+  secret-scan:
+    name: Secret Scan (Gitleaks)
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          args: detect --report-format sarif --report-path gitleaks.sarif
+      - name: Upload Gitleaks SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-sarif
+          path: gitleaks.sarif
+      - name: Publish Gitleaks SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
   unit:
     name: Unit Tests (${{ matrix.service }} · Node ${{ matrix.node }})
-    needs: lint
+    needs: [lint, secret-scan]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -145,7 +168,7 @@ jobs:
 
   integration:
     name: Integration Tests (${{ matrix.service }} · Node ${{ matrix.node }})
-    needs: unit
+    needs: [unit, secret-scan]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -222,7 +245,7 @@ jobs:
 
   contract:
     name: Contract Tests (${{ matrix.service }} · Node ${{ matrix.node }})
-    needs: integration
+    needs: [integration, secret-scan]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -315,7 +338,7 @@ jobs:
 
   coverage:
     name: Coverage summary
-    needs: [unit, integration, contract]
+    needs: [unit, integration, contract, secret-scan]
     runs-on: ubuntu-latest
     env:
       COVERAGE_THRESHOLD: '80'
@@ -403,7 +426,7 @@ jobs:
 
   sast:
     name: SAST (CodeQL)
-    needs: lint
+    needs: [lint, secret-scan]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -428,7 +451,7 @@ jobs:
 
   trivy:
     name: Trivy FS & Image Scans
-    needs: [contract]
+    needs: [contract, secret-scan]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/operations/ci-cd.md
+++ b/docs/operations/ci-cd.md
@@ -9,7 +9,17 @@
 > - Dashboards: [Grafana CI/CD](https://grafana.smartedify.internal/d/cicd)
 
 ## Gates obligatorios
-- `lint`, `typecheck`, `test:unit`, `test:int`, `openapi:lint`, `sbom`, `sast`, `container:scan`.
+- `lint`, `typecheck`, `test:unit`, `test:int`, `openapi:lint`, `sbom`, `sast`, `container:scan`, `secret-scan`.
+
+### `secret-scan`
+- Detecta *leaks* y credenciales accidentales utilizando [Gitleaks](https://github.com/gitleaks/gitleaks).
+- El pipeline sube los resultados en formato SARIF a Code Scanning y bloquea el merge si el job falla.
+- Para reproducirlo localmente desde la raíz del repo:
+  ```bash
+  docker run --rm -v "$(pwd)":/repo -w /repo zricethezav/gitleaks:latest \
+    detect --report-format sarif --report-path gitleaks.sarif
+  ```
+  El archivo `gitleaks.sarif` puede abrirse con VS Code o subirse manualmente a GitHub Code Scanning para revisión.
 
 ## Estrategia de despliegue
 - *Canary* por servicio con *feature flags*.


### PR DESCRIPTION
## Summary
- add a Gitleaks-based `secret-scan` job that uploads SARIF results
- require the new gate alongside linting for downstream CI jobs
- document the gate and local reproduction command in the CI/CD runbook

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9a2b968688329bc0f0fc909b16ff8