### PR TITLE
test: cover jwks rotation and jwt expiration

### DIFF
--- a/apps/services/auth-service/README.md
+++ b/apps/services/auth-service/README.md
@@ -192,6 +192,10 @@ Limitaciones pendientes:
 - Endpoint de rotación sin control de acceso.
 - Faltan alertas sobre ausencia de `next` o edad excesiva de `current`.
 
+### Validación automatizada
+- `tests/security/keys.test.ts` garantiza que la rotación promueve `next`, deja la clave previa en `retiring` y que `getPublicJwks()` publica simultáneamente `current`, `next` y `retiring`.
+- `tests/security/jwt.test.ts` simula expiraciones y desfases de reloj ajustando temporalmente los TTL de access/refresh para confirmar que los tokens caducados se rechazan y que existe tolerancia antes de alcanzar el límite.
+
 Pruebas locales rápidas:
 ```bash
 curl -s http://localhost:8080/.well-known/jwks.json | jq


### PR DESCRIPTION
## Summary
- extend signing key rotation tests to assert retiring status and JWKS publication of current/next/retiring
- add JWT security tests that simulate expiration and small clock skew windows by adjusting TTLs and mocking Date
- document the new automated checks in the auth-service README

## Testing
- npm run test:security *(fails: local Jest binary is missing and fetching jest from the registry is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d04864f48329a9993164e817017c