### PR TITLE
feat(auth-service): protect admin key rotation endpoints

### DIFF
--- a/apps/services/auth-service/internal/middleware/admin-auth.ts
+++ b/apps/services/auth-service/internal/middleware/admin-auth.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from 'express';
+
+const DEFAULT_HEADER = 'x-admin-api-key';
+
+function getHeaderName(): string {
+  const raw = process.env.AUTH_ADMIN_API_HEADER;
+  return (raw && raw.trim()) || DEFAULT_HEADER;
+}
+
+function getExpectedCredential(): string | null {
+  const raw = process.env.AUTH_ADMIN_API_KEY;
+  if (!raw || !raw.trim()) {
+    return null;
+  }
+  return raw;
+}
+
+export function adminAuthMiddleware(req: Request, res: Response, next: NextFunction) {
+  const expected = getExpectedCredential();
+  if (!expected) {
+    res.status(503).json({ error: 'admin_auth_unconfigured' });
+    return;
+  }
+  const headerName = getHeaderName();
+  const provided = req.header(headerName);
+  if (!provided) {
+    res.status(401).json({ error: 'admin_auth_required' });
+    return;
+  }
+  if (provided !== expected) {
+    res.status(403).json({ error: 'admin_auth_invalid' });
+    return;
+  }
+  next();
+}
+
+export function __resetAdminAuthForTests() {
+  if (process.env.NODE_ENV !== 'test') return;
+  // Allow tests to mutate configuration between cases if needed.
+  // Currently nothing to reset, but keep hook for parity with other middleware helpers.
+}

--- a/apps/services/auth-service/tests/integration/admin-auth.integration.test.ts
+++ b/apps/services/auth-service/tests/integration/admin-auth.integration.test.ts
@@ -1,0 +1,48 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import request from 'supertest';
+import { app } from '../../cmd/server/main';
+import pool from '../../internal/adapters/db/pg.adapter';
+import redis from '../../internal/adapters/redis/redis.adapter';
+import { __resetKeyCacheForTests } from '../../internal/security/keys';
+
+describe('Middleware administrativo', () => {
+  const headerName = process.env.AUTH_ADMIN_API_HEADER || 'x-admin-api-key';
+  const adminKey = process.env.AUTH_ADMIN_API_KEY as string;
+
+  if (!adminKey) {
+    throw new Error('AUTH_ADMIN_API_KEY debe configurarse para las pruebas de integración');
+  }
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE TABLE auth_signing_keys RESTART IDENTITY CASCADE');
+    await (redis as any).flushdb?.();
+    __resetKeyCacheForTests();
+  });
+
+  it.each([
+    ['/admin/rotate-keys', undefined],
+    ['/admin/revoke-kid', { kid: 'demo' }]
+  ])('retorna 401 sin credencial en %s', async (path, payload) => {
+    const agent = request(app).post(path);
+    const response = payload ? await agent.send(payload) : await agent.send();
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('admin_auth_required');
+  });
+
+  it('retorna 403 si la credencial es inválida', async () => {
+    const res = await request(app)
+      .post('/admin/rotate-keys')
+      .set(headerName, 'credencial-invalida');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('admin_auth_invalid');
+  });
+
+  it('permite acceder cuando la credencial es válida', async () => {
+    const res = await request(app)
+      .post('/admin/rotate-keys')
+      .set(headerName, adminKey);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('rotated');
+  });
+});

--- a/apps/services/auth-service/tests/integration/jest.integration.setup.ts
+++ b/apps/services/auth-service/tests/integration/jest.integration.setup.ts
@@ -1,6 +1,13 @@
 // Setup específico de la suite 'integration'
 // Debe ejecutarse ANTES de importar cualquier módulo que cree instancias de Redis/Pool.
 process.env.NODE_ENV = 'test';
+// Configuración por defecto del guard administrativo para pruebas de integración
+if (!process.env.AUTH_ADMIN_API_KEY) {
+  process.env.AUTH_ADMIN_API_KEY = 'integration-admin-secret';
+}
+if (!process.env.AUTH_ADMIN_API_HEADER) {
+  process.env.AUTH_ADMIN_API_HEADER = 'x-admin-api-key';
+}
 // Mock de ioredis para garantizar que la instancia usada en redis.adapter tenga incr/ttl/expire
 jest.mock('ioredis');
 


### PR DESCRIPTION
## Summary
- add an administrative auth middleware backed by a configurable API key header
- enforce the middleware on key rotation and revocation endpoints and document the required environment variables
- cover the guard with integration tests that assert 401/403/200 flows

## Testing
- ⚠️ `npm run test:proj:integration` *(fails: local Jest binary not available because npm install could not download packages due to registry 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68caabb8d3908329b03564251cedd310