### PR TITLE
Add Schemathesis contract smoke wrappers and CI job

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -62,3 +62,39 @@ jobs:
             echo "Spectral lint $f";
             spectral lint "$f" || exit 1;
           done
+
+  contract-tests:
+    name: schemathesis-contracts
+    runs-on: ubuntu-latest
+    needs: quality-gates
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install service dependencies
+        run: |
+          npm ci --prefix apps/services/auth-service
+          npm ci --prefix apps/services/tenant-service
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Schemathesis tooling
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-schemathesis.txt
+
+      - name: Ejecutar contratos Auth (Schemathesis)
+        run: npm run contract:auth:schemathesis
+
+      - name: Ejecutar contratos Tenant (Schemathesis)
+        run: npm run contract:tenant:schemathesis
+
+      - name: Publicar reportes Schemathesis
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: schemathesis-reports
+          path: reports/contracts

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ SmartEdify es una plataforma modular orientada a servicios (Auth, Tenant, User, 
     npm --prefix apps/services/tenant-service run test
     npm --prefix apps/services/tenant-service run test:integration
     ```
+  - Contratos HTTP (Schemathesis):
+    ```sh
+    python -m pip install -r requirements-schemathesis.txt
+    npm run contract:auth:schemathesis
+    npm run contract:tenant:schemathesis
+    ```
+    - Los wrappers inician cada servicio con `SKIP_DB_TESTS=1`, esperan `/health` y ejecutan un smoke test sobre el contrato (`/health`).
+    - Los reportes JUnit se guardan en `reports/contracts/` y pueden subirse como artefactos en CI.
 
 ### Ejecución rápida de tests (scripts raíz)
   - Windows (PowerShell 5.1+):

--- a/apps/services/tenant-service/README.md
+++ b/apps/services/tenant-service/README.md
@@ -78,6 +78,18 @@ npm run build
 npm start
 ```
 
+## Contratos HTTP (Schemathesis)
+
+Ejecuta el smoke test de contrato basado en OpenAPI con Schemathesis:
+
+```bash
+python -m pip install -r requirements-schemathesis.txt
+npm run contract:tenant:schemathesis
+```
+
+- El script inicia el servidor con `SKIP_DB_TESTS=1`, espera `http://127.0.0.1:18083/health` y ejercita el endpoint de salud.
+- El reporte JUnit se genera en `reports/contracts/tenant-service-schemathesis.xml` para ser consumido por CI.
+
 ## Métricas Iniciales (definición)
 Actual (Fase 0 + Operability Addendum):
 

--- a/docs/testing/auth-service-strategy.md
+++ b/docs/testing/auth-service-strategy.md
@@ -35,6 +35,9 @@ Conteo consolidado: 47 tests (18 suites) tras eliminar duplicados de password re
 
 ## Contratos y *snapshots*
 - Próximo hito: pruebas de contrato HTTP desde OpenAPI (`api/auth.yaml`) usando Spectral + Schemathesis.
+- Smoke test con Schemathesis disponible vía `npm run contract:auth:schemathesis` tras instalar `pip install -r requirements-schemathesis.txt`.
+  - El wrapper levanta el servidor con `SKIP_DB_TESTS=1`, espera `http://127.0.0.1:18080/health` y ejecuta Schemathesis contra ese endpoint.
+  - Los resultados quedan en `reports/contracts/auth-service-schemathesis.xml` (JUnit) para su publicación en CI.
 - Uso moderado de snapshots: sanitizar tokens (`<JWT>` / `<REFRESH>` / `<RESET_TOKEN>`).
  - Snapshots actuales alineados (0 obsoletos tras limpieza); el `contractSnapshot` normaliza headers (`x-request-id`) y números variables.
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:fast:nix": "npm run test:auth:nix",
     "test:fast:win": "npm run test:auth:win",
     "test:contract:nix": "cd apps/services/auth-service && SKIP_DB_TESTS=1 NODE_ENV=test AUTH_ADMIN_API_KEY=test-admin-key npm run test:proj:contract --silent",
-    "test:contract:win": "cd apps\\services\\auth-service && set SKIP_DB_TESTS=1&& set NODE_ENV=test&& set AUTH_ADMIN_API_KEY=test-admin-key&& npm run test:proj:contract --silent"
+    "test:contract:win": "cd apps\\services\\auth-service && set SKIP_DB_TESTS=1&& set NODE_ENV=test&& set AUTH_ADMIN_API_KEY=test-admin-key&& npm run test:proj:contract --silent",
+    "contract:auth:schemathesis": "node scripts/contracts/run-schemathesis.js auth",
+    "contract:tenant:schemathesis": "node scripts/contracts/run-schemathesis.js tenant"
   }
 }

--- a/requirements-schemathesis.txt
+++ b/requirements-schemathesis.txt
@@ -1,0 +1,1 @@
+schemathesis==3.27.6

--- a/scripts/contracts/run-schemathesis.js
+++ b/scripts/contracts/run-schemathesis.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { setTimeout: delay } = require('node:timers/promises');
+
+const rootDir = path.resolve(__dirname, '..', '..');
+
+const schemathesisCmd = process.platform === 'win32' ? 'schemathesis.exe' : 'schemathesis';
+const nodeCmd = process.execPath;
+
+const scenarios = {
+  auth: {
+    name: 'auth-service',
+    cwd: path.join(rootDir, 'apps/services/auth-service'),
+    start: {
+      command: nodeCmd,
+      args: ['cmd/server/main.js'],
+    },
+    env: {
+      NODE_ENV: 'test',
+      SKIP_DB_TESTS: '1',
+      AUTH_ADMIN_API_KEY: 'schemathesis-admin-key',
+      AUTH_JWT_ACCESS_SECRET: 'schemathesis-access-secret',
+      AUTH_JWT_REFRESH_SECRET: 'schemathesis-refresh-secret',
+      AUTH_USER_SERVICE_MODE: 'mock',
+      AUTH_PORT: '18080',
+      PORT: '18080',
+      PGHOST: '127.0.0.1',
+      PGPORT: '65432',
+      REDIS_HOST: '127.0.0.1',
+      REDIS_PORT: '6655',
+    },
+    readinessUrl: 'http://127.0.0.1:18080/health',
+    baseUrl: 'http://127.0.0.1:18080',
+    specPath: path.join(rootDir, 'apps/services/auth-service/api/openapi.yaml'),
+    reportFile: 'auth-service-schemathesis.xml',
+    extraArgs: ['--endpoint=/health'],
+  },
+  tenant: {
+    name: 'tenant-service',
+    cwd: path.join(rootDir, 'apps/services/tenant-service'),
+    start: {
+      command: nodeCmd,
+      args: [path.join('node_modules', 'tsx', 'dist', 'cli.js'), 'cmd/server/main.ts'],
+      env: { TSX_TRANSPILE_ONLY: 'true' },
+    },
+    env: {
+      NODE_ENV: 'test',
+      SKIP_DB_TESTS: '1',
+      TENANT_PORT: '18083',
+      PGHOST: '127.0.0.1',
+      PGPORT: '65433',
+      POSTGRES_USER: 'postgres',
+      POSTGRES_PASSWORD: 'postgres',
+      POSTGRES_DB: 'schemathesis',
+      TENANT_PUBLISHER: 'logging',
+      TENANT_CONSUMER: 'none',
+    },
+    readinessUrl: 'http://127.0.0.1:18083/health',
+    baseUrl: 'http://127.0.0.1:18083',
+    specPath: path.join(rootDir, 'apps/services/tenant-service/api/openapi/tenant.yaml'),
+    reportFile: 'tenant-service-schemathesis.xml',
+    extraArgs: ['--endpoint=/health'],
+  },
+};
+
+async function waitForService(url, timeoutMs = 30000, intervalMs = 500) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const controller = AbortSignal.timeout(2000);
+      const response = await fetch(url, { signal: controller });
+      if (response && response.status < 500) {
+        return;
+      }
+    } catch (err) {
+      // retry
+    }
+    await delay(intervalMs);
+  }
+  throw new Error(`Timeout esperando a que ${url} esté disponible`);
+}
+
+function spawnProcess(command, args, options, { fatal = false } = {}) {
+  const child = spawn(command, args, options);
+  child.on('error', error => {
+    console.error(`[schemathesis] Falló el comando ${command}:`, error);
+    if (fatal) {
+      process.exit(1);
+    }
+  });
+  return child;
+}
+
+async function run() {
+  const target = process.argv[2];
+  if (!target || !scenarios[target]) {
+    console.error('Uso: node scripts/contracts/run-schemathesis.js <auth|tenant>');
+    process.exit(1);
+  }
+
+  const scenario = scenarios[target];
+  const env = { ...process.env, ...scenario.env };
+
+  console.log(`[schemathesis] Iniciando ${scenario.name} en modo contrato...`);
+  const startCommand = scenario.start?.command ?? nodeCmd;
+  const startArgs = scenario.start?.args ?? ['cmd/server/main.js'];
+  const serverEnv = { ...env, ...(scenario.start?.env ?? {}) };
+  const server = spawnProcess(startCommand, startArgs, {
+    cwd: scenario.cwd,
+    env: serverEnv,
+    stdio: 'inherit',
+  }, { fatal: true });
+
+  let serverExited = false;
+  server.on('exit', code => {
+    serverExited = true;
+    if (code !== 0) {
+      console.error(`[schemathesis] ${scenario.name} terminó con código ${code}`);
+      process.exit(code ?? 1);
+    }
+  });
+
+  const stopServer = () => {
+    if (!server.killed && !serverExited) {
+      server.kill('SIGTERM');
+    }
+  };
+
+  const handleSignal = signal => {
+    console.log(`[schemathesis] Recibida señal ${signal}, deteniendo servidor...`);
+    stopServer();
+    process.exit(1);
+  };
+
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
+
+  try {
+    await waitForService(scenario.readinessUrl);
+  } catch (error) {
+    console.error(`[schemathesis] No se pudo iniciar ${scenario.name}: ${error.message}`);
+    stopServer();
+    process.exit(1);
+  }
+
+  const reportDir = path.join(rootDir, 'reports', 'contracts');
+  fs.mkdirSync(reportDir, { recursive: true });
+  const reportPath = path.join(reportDir, scenario.reportFile);
+
+  const schemathesisArgs = [
+    'run',
+    scenario.specPath,
+    '--base-url',
+    scenario.baseUrl,
+    '--checks=not_a_server_error',
+    '--junit-xml',
+    reportPath,
+    '--workers',
+    '1',
+    '--hypothesis-max-examples',
+    '1',
+    '--hypothesis-derandomize',
+    ...scenario.extraArgs,
+  ];
+
+  console.log('[schemathesis] Ejecutando:', schemathesisCmd, schemathesisArgs.join(' '));
+  const tester = spawnProcess(schemathesisCmd, schemathesisArgs, {
+    cwd: rootDir,
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  tester.on('exit', code => {
+    stopServer();
+    if (code !== 0) {
+      console.error(`[schemathesis] Schemathesis finalizó con código ${code}`);
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+run().catch(error => {
+  console.error('[schemathesis] Error inesperado:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a dedicated Python requirements file and a reusable runner to start services in contract mode and execute Schemathesis
- expose npm scripts plus a CI workflow job that installs Schemathesis, runs the smoke contracts for auth & tenant, and archives reports
- document the new commands in the root README, auth testing strategy, and tenant README

## Testing
- python3 -m pip install -r requirements-schemathesis.txt *(fails: ProxyError 403 Forbidden while reaching PyPI)*
- npm run contract:auth:schemathesis *(fails: local dependencies unavailable in the execution environment)*
- npm run contract:tenant:schemathesis *(fails: local dependencies unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaf7bbe248329ae7bb859923c02a3