### PR TITLE
Add tracing helper and instrument auth/tenant flows

### DIFF
--- a/apps/services/auth-service/internal/adapters/http/login.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/login.handler.ts
@@ -5,62 +5,76 @@ import { verifyPassword } from '../../security/crypto';
 import { issueTokenPair, verifyRefresh } from '../../security/jwt';
 import * as pgAdapter from '@db/pg.adapter';
 import { saveSession } from '../redis/redis.adapter';
+import { withSpan } from '@smartedify/shared/tracing';
 
 import { LoginRequestSchema } from './login.dto';
 
 const DEFAULT_ROLE = process.env.AUTH_DEFAULT_ROLE || 'user';
+const AUTH_TRACER = process.env.AUTH_SERVICE_NAME || 'auth-service';
 
 export async function loginHandler(req: Request, res: Response) {
-  const parseResult = LoginRequestSchema.safeParse(req.body);
-  if (!parseResult.success) {
-    return res.status(400).json({ error: 'Datos inválidos', details: parseResult.error.errors });
-  }
-  const { email, password } = parseResult.data;
-  const tenant_id = req.body.tenant_id || 'default';
-  const user = await pgAdapter.getUserByEmail(email, tenant_id);
-  if (process.env.AUTH_TEST_LOGS) console.log('[login] fetched user', user);
-  let valid = false;
-  if (user) {
-    valid = await verifyPassword(user.pwd_hash, password);
-    if (process.env.AUTH_TEST_LOGS) console.log('[login] verifyPassword', user.pwd_hash, password, '=>', valid);
-  }
-  if (!user || !valid) {
-    loginFailCounter.inc();
-    return res.status(401).json({ error: 'Credenciales inválidas' });
-  }
-  // Generar tokens (access + refresh)
-  let roles: string[] = [];
-  try {
-  roles = await pgAdapter.getUserRoles(user.id, tenant_id);
-  } catch (e) {
-    if (process.env.AUTH_TEST_LOGS) console.error('[login] getUserRoles failed', e);
-  }
-  if (!roles || roles.length === 0) roles = [DEFAULT_ROLE];
-  const pair = await issueTokenPair({ sub: user.id, tenant_id, roles });
-  // Sesión corta (opcional) para tracking
-  let sessionId: string | null = null;
-  try {
-    const refreshPayload: any = await verifyRefresh(pair.refreshToken);
-    sessionId = typeof refreshPayload?.jti === 'string' ? refreshPayload.jti : null;
-  } catch (e) {
-    if (process.env.AUTH_TEST_LOGS) console.warn('[login] verifyRefresh for session failed', (e as any)?.message);
-  }
-  const sessionKey = sessionId || pair.accessToken.substring(0, 24);
-  await saveSession(sessionKey, {
-    userId: user.id,
-    tenant_id,
-    access_kid: pair.accessKid,
-    refresh_kid: pair.refreshKid,
-    access_jti: pair.accessJti,
-    refresh_jti: pair.refreshJti
-  }, pair.expiresIn);
-  loginSuccessCounter.inc();
-  return res.status(200).json({
-    message: 'Login exitoso',
-    access_token: pair.accessToken,
-    refresh_token: pair.refreshToken,
-    token_type: 'Bearer',
-    expires_in: pair.expiresIn,
-    roles
+  const tenantId = typeof req.body?.tenant_id === 'string' && req.body.tenant_id.trim()
+    ? req.body.tenant_id
+    : 'default';
+
+  return withSpan(AUTH_TRACER, 'auth.login', { 'auth.tenant_id': tenantId }, async span => {
+    const parseResult = LoginRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      span.setAttribute('auth.result', 'validation_error');
+      span.addEvent('login.failure', { reason: 'validation_error' });
+      return res.status(400).json({ error: 'Datos inválidos', details: parseResult.error.errors });
+    }
+    const { email, password } = parseResult.data;
+    const user = await pgAdapter.getUserByEmail(email, tenantId);
+    if (process.env.AUTH_TEST_LOGS) console.log('[login] fetched user', user);
+    let valid = false;
+    if (user) {
+      span.setAttribute('auth.user_id', user.id);
+      valid = await verifyPassword(user.pwd_hash, password);
+      if (process.env.AUTH_TEST_LOGS) console.log('[login] verifyPassword', user.pwd_hash, password, '=>', valid);
+    }
+    if (!user || !valid) {
+      span.setAttribute('auth.result', 'invalid_credentials');
+      span.addEvent('login.failure', { reason: 'invalid_credentials' });
+      loginFailCounter.inc();
+      return res.status(401).json({ error: 'Credenciales inválidas' });
+    }
+    // Generar tokens (access + refresh)
+    let roles: string[] = [];
+    try {
+      roles = await pgAdapter.getUserRoles(user.id, tenantId);
+    } catch (e) {
+      if (process.env.AUTH_TEST_LOGS) console.error('[login] getUserRoles failed', e);
+    }
+    if (!roles || roles.length === 0) roles = [DEFAULT_ROLE];
+    const pair = await issueTokenPair({ sub: user.id, tenant_id: tenantId, roles });
+    // Sesión corta (opcional) para tracking
+    let sessionId: string | null = null;
+    try {
+      const refreshPayload: any = await verifyRefresh(pair.refreshToken);
+      sessionId = typeof refreshPayload?.jti === 'string' ? refreshPayload.jti : null;
+    } catch (e) {
+      if (process.env.AUTH_TEST_LOGS) console.warn('[login] verifyRefresh for session failed', (e as any)?.message);
+    }
+    const sessionKey = sessionId || pair.accessToken.substring(0, 24);
+    await saveSession(sessionKey, {
+      userId: user.id,
+      tenant_id: tenantId,
+      access_kid: pair.accessKid,
+      refresh_kid: pair.refreshKid,
+      access_jti: pair.accessJti,
+      refresh_jti: pair.refreshJti
+    }, pair.expiresIn);
+    span.setAttribute('auth.result', 'success');
+    span.addEvent('login.success', { 'auth.user_id': user.id, 'auth.tenant_id': tenantId });
+    loginSuccessCounter.inc();
+    return res.status(200).json({
+      message: 'Login exitoso',
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: 'Bearer',
+      expires_in: pair.expiresIn,
+      roles
+    });
   });
 }

--- a/apps/services/auth-service/internal/adapters/http/refresh.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/refresh.handler.ts
@@ -2,22 +2,46 @@ import { Request, Response } from 'express';
 
 import { refreshRotatedCounter, refreshReuseBlockedCounter } from '../../../cmd/server/main';
 import { rotateRefresh } from '../../security/jwt';
+import { withSpan } from '@smartedify/shared/tracing';
+
+const AUTH_TRACER = process.env.AUTH_SERVICE_NAME || 'auth-service';
 
 export async function refreshHandler(req: Request, res: Response) {
   const token = (req.body && req.body.refresh_token) || req.headers['x-refresh-token'];
-  if (!token || typeof token !== 'string') {
-    return res.status(400).json({ error: 'refresh_token requerido' });
-  }
-  const pair = await rotateRefresh(token);
-  if (!pair) {
-    refreshReuseBlockedCounter.inc();
-    return res.status(401).json({ error: 'Refresh token inválido o expirado' });
-  }
-  refreshRotatedCounter.inc();
-  return res.status(200).json({
-    access_token: pair.accessToken,
-    refresh_token: pair.refreshToken,
-    token_type: 'Bearer',
-    expires_in: pair.expiresIn
+
+  return withSpan(AUTH_TRACER, 'auth.refresh', undefined, async span => {
+    if (!token || typeof token !== 'string') {
+      span.setAttribute('auth.result', 'validation_error');
+      span.addEvent('refresh.failure', { reason: 'missing_token' });
+      return res.status(400).json({ error: 'refresh_token requerido' });
+    }
+
+    const pair = await rotateRefresh(token);
+    if (!pair) {
+      span.setAttribute('auth.result', 'invalid_token');
+      span.addEvent('refresh.failure', { reason: 'rotate_failed' });
+      refreshReuseBlockedCounter.inc();
+      return res.status(401).json({ error: 'Refresh token inválido o expirado' });
+    }
+
+    if (pair.sub) {
+      span.setAttribute('auth.user_id', pair.sub);
+    }
+    if (pair.tenant_id) {
+      span.setAttribute('auth.tenant_id', pair.tenant_id);
+    }
+    span.setAttribute('auth.result', 'success');
+    span.addEvent('refresh.success', {
+      ...(pair.sub ? { 'auth.user_id': pair.sub } : {}),
+      ...(pair.tenant_id ? { 'auth.tenant_id': pair.tenant_id } : {})
+    });
+
+    refreshRotatedCounter.inc();
+    return res.status(200).json({
+      access_token: pair.accessToken,
+      refresh_token: pair.refreshToken,
+      token_type: 'Bearer',
+      expires_in: pair.expiresIn
+    });
   });
 }

--- a/apps/services/auth-service/internal/adapters/http/register.handler.ts
+++ b/apps/services/auth-service/internal/adapters/http/register.handler.ts
@@ -4,81 +4,97 @@ import { getUserServiceClient } from '../user-service.client';
 import { hashPassword } from '../../security/crypto';
 import * as pgAdapter from '@db/pg.adapter';
 import { RegisterRequestSchema } from './register.dto';
+import { withSpan } from '@smartedify/shared/tracing';
 
 const DEFAULT_ROLE = process.env.AUTH_DEFAULT_ROLE || 'user';
+const AUTH_TRACER = process.env.AUTH_SERVICE_NAME || 'auth-service';
 
 export async function registerHandler(req: Request, res: Response) {
-  const parseResult = RegisterRequestSchema.safeParse(req.body);
-  if (!parseResult.success) {
-    return res.status(400).json({ error: 'Datos inválidos', details: parseResult.error.errors });
-  }
-  const { email, password, name } = parseResult.data;
-  // Generamos un id por consistencia (aunque createUser puede generar)
-  const _id = uuidv4();
-  const tenant_id = (req as any).body?.tenant_id || 'default';
+  const tenantId = typeof (req as any)?.body?.tenant_id === 'string' && (req as any).body.tenant_id.trim()
+    ? (req as any).body.tenant_id
+    : 'default';
 
-  const userServiceClient = getUserServiceClient();
-  let validation: any;
-  try {
-    validation = await userServiceClient.validateUser({ email, tenantId: tenant_id, name });
-  } catch (err) {
-    if (process.env.AUTH_TEST_LOGS) {
-      console.error('[register] User Service validation failed', err);
+  return withSpan(AUTH_TRACER, 'auth.register', { 'auth.tenant_id': tenantId }, async span => {
+    const parseResult = RegisterRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      span.setAttribute('auth.result', 'validation_error');
+      return res.status(400).json({ error: 'Datos inválidos', details: parseResult.error.errors });
     }
-    return res.status(502).json({ error: 'User Service no disponible', details: err instanceof Error ? err.message : String(err) });
-  }
+    const { email, password, name } = parseResult.data;
+    // Generamos un id por consistencia (aunque createUser puede generar)
+    const _id = uuidv4();
 
-  if (!validation?.allowed) {
-    return res.status(403).json({ error: 'Usuario no permitido por User Service', status: validation?.status });
-  }
-
-  const accountStatus = validation.status || 'active';
-  const existing = await pgAdapter.getUserByEmail(email, tenant_id);
-  if (existing) {
-    return res.status(409).json({ error: 'El usuario ya existe' });
-  }
-
-  const hashed = await hashPassword(password);
-  const user = await pgAdapter.createUser({
-    tenant_id,
-    email,
-    pwd_hash: hashed,
-    pwd_salt: '',
-    name,
-    status: accountStatus,
-    created_at: new Date()
-  });
-
-  const rolesToAssign: string[] = Array.isArray(validation.roles) && validation.roles.length > 0
-    ? validation.roles
-    : [DEFAULT_ROLE];
-  const uniqueRoles = Array.from(new Set(rolesToAssign));
-  for (const role of uniqueRoles) {
+    const userServiceClient = getUserServiceClient();
+    let validation: any;
     try {
-      await pgAdapter.assignUserRole(user.id, tenant_id, role);
-    } catch (e) {
-      if (process.env.AUTH_TEST_LOGS) console.error('[register] assignUserRole failed', e);
+      validation = await userServiceClient.validateUser({ email, tenantId, name });
+    } catch (err) {
+      if (process.env.AUTH_TEST_LOGS) {
+        console.error('[register] User Service validation failed', err);
+      }
+      span.setAttribute('auth.result', 'user_service_unavailable');
+      return res.status(502).json({ error: 'User Service no disponible', details: err instanceof Error ? err.message : String(err) });
     }
-  }
 
-  let roles: string[] = [];
-  try {
-    roles = await pgAdapter.getUserRoles(user.id, tenant_id);
-  } catch (e) {
-    if (process.env.AUTH_TEST_LOGS) console.error('[register] getUserRoles failed', e);
-  }
-  if (!roles || roles.length === 0) roles = uniqueRoles.length ? uniqueRoles : [DEFAULT_ROLE];
-  const permissions: string[] = Array.isArray(validation.permissions) ? validation.permissions : [];
+    if (!validation?.allowed) {
+      span.setAttribute('auth.result', 'forbidden');
+      return res.status(403).json({ error: 'Usuario no permitido por User Service', status: validation?.status });
+    }
 
-  return res.status(201).json({
-    message: 'Usuario registrado',
-    user: {
-      id: user.id,
+    const accountStatus = validation.status || 'active';
+    const existing = await pgAdapter.getUserByEmail(email, tenantId);
+    if (existing) {
+      span.setAttribute('auth.result', 'conflict');
+      span.setAttribute('auth.user_id', existing.id);
+      return res.status(409).json({ error: 'El usuario ya existe' });
+    }
+
+    const hashed = await hashPassword(password);
+    const user = await pgAdapter.createUser({
+      tenant_id: tenantId,
       email,
+      pwd_hash: hashed,
+      pwd_salt: '',
       name,
       status: accountStatus,
-      roles,
-      permissions
+      created_at: new Date()
+    });
+
+    span.setAttribute('auth.user_id', user.id);
+
+    const rolesToAssign: string[] = Array.isArray(validation.roles) && validation.roles.length > 0
+      ? validation.roles
+      : [DEFAULT_ROLE];
+    const uniqueRoles = Array.from(new Set(rolesToAssign));
+    for (const role of uniqueRoles) {
+      try {
+        await pgAdapter.assignUserRole(user.id, tenantId, role);
+      } catch (e) {
+        if (process.env.AUTH_TEST_LOGS) console.error('[register] assignUserRole failed', e);
+      }
     }
+
+    let roles: string[] = [];
+    try {
+      roles = await pgAdapter.getUserRoles(user.id, tenantId);
+    } catch (e) {
+      if (process.env.AUTH_TEST_LOGS) console.error('[register] getUserRoles failed', e);
+    }
+    if (!roles || roles.length === 0) roles = uniqueRoles.length ? uniqueRoles : [DEFAULT_ROLE];
+    const permissions: string[] = Array.isArray(validation.permissions) ? validation.permissions : [];
+
+    span.setAttribute('auth.result', 'success');
+
+    return res.status(201).json({
+      message: 'Usuario registrado',
+      user: {
+        id: user.id,
+        email,
+        name,
+        status: accountStatus,
+        roles,
+        permissions
+      }
+    });
   });
 }

--- a/apps/services/auth-service/tests/unit/login.test.ts
+++ b/apps/services/auth-service/tests/unit/login.test.ts
@@ -1,8 +1,22 @@
 import request from 'supertest';
 
 import app from '../app.test';
+import { loginSuccessCounter, loginFailCounter } from '../../cmd/server/main';
+
+function counterValue(counter: { get: () => { values: Array<{ value: number }> }; reset: () => void }): number {
+  const snapshot = counter.get();
+  if (!snapshot || !Array.isArray(snapshot.values) || snapshot.values.length === 0) {
+    return 0;
+  }
+  return snapshot.values[0]?.value ?? 0;
+}
 
 describe('POST /login', () => {
+  beforeEach(() => {
+    loginSuccessCounter.reset();
+    loginFailCounter.reset();
+  });
+
   // Uso de mock pg in-memory global; no limpiar memory local obsoleta
   it('debe aceptar login válido', async () => {
     const email = `user_${Date.now()}@demo.com`;
@@ -16,6 +30,20 @@ describe('POST /login', () => {
     expect(res.body.message).toBe('Login exitoso');
     expect(res.body.access_token).toBeDefined();
     expect(res.body.refresh_token).toBeDefined();
+    expect(counterValue(loginSuccessCounter)).toBeGreaterThanOrEqual(1);
+  });
+
+  it('incrementa métrica de fallos con credenciales incorrectas', async () => {
+    const email = `user_fail_${Date.now()}@demo.com`;
+    await request(app)
+      .post('/register')
+      .send({ email, password: 'ValidPass123', name: 'Fail User' });
+    const res = await request(app)
+      .post('/login')
+      .send({ email, password: 'WrongPass123' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Credenciales inválidas');
+    expect(counterValue(loginFailCounter)).toBeGreaterThanOrEqual(1);
   });
 
   it('debe rechazar login inválido', async () => {

--- a/apps/services/tenant-service/internal/adapters/http/routes/memberships.ts
+++ b/apps/services/tenant-service/internal/adapters/http/routes/memberships.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { membershipActiveGauge } from '../../../metrics/registry.js';
+import { withSpan } from '@smartedify/shared/tracing';
+import { getActiveTraceparent } from '../../../observability/trace-context.js';
 
 const createMembershipSchema = z.object({
   userId: z.string().uuid(),
@@ -9,28 +11,49 @@ const createMembershipSchema = z.object({
   validTo: z.string().datetime().optional()
 });
 
+const TENANT_TRACER = process.env.TENANT_SERVICE_NAME || 'tenant-service';
+
 export async function membershipRoutes(app: FastifyInstance) {
   const membershipRepo = app.di.membershipRepo;
   app.post('/units/:unitId/memberships', async (req, reply) => {
     // @ts-ignore simplifying
     const { unitId } = req.params;
-    const parsed = createMembershipSchema.safeParse(req.body);
-    if (!parsed.success) return reply.status(400).send({ error: 'validation_error', details: parsed.error.flatten() });
-    const m = await membershipRepo.create({
-      unitId,
-      userId: parsed.data.userId,
-      relation: parsed.data.relation,
-      validFrom: new Date(parsed.data.validFrom),
-      validTo: parsed.data.validTo ? new Date(parsed.data.validTo) : undefined
+    return withSpan(TENANT_TRACER, 'tenant.membership.create', { 'unit.id': unitId }, async span => {
+      const parsed = createMembershipSchema.safeParse(req.body);
+      if (!parsed.success) {
+        span.setAttribute('membership.result', 'validation_error');
+        return reply.status(400).send({ error: 'validation_error', details: parsed.error.flatten() });
+      }
+      const m = await membershipRepo.create({
+        unitId,
+        userId: parsed.data.userId,
+        relation: parsed.data.relation,
+        validFrom: new Date(parsed.data.validFrom),
+        validTo: parsed.data.validTo ? new Date(parsed.data.validTo) : undefined
+      });
+      const active = await membershipRepo.countActive();
+      membershipActiveGauge.set(active);
+      span.setAttribute('membership.id', m.id);
+      span.setAttribute('membership.user_id', m.userId);
+      span.setAttribute('membership.result', 'success');
+      span.addEvent('tenant.membership.created', { 'membership.id': m.id, 'unit.id': m.unitId });
+      const traceparent = getActiveTraceparent();
+      const payload: Record<string, unknown> = {
+        id: m.id,
+        unitId: m.unitId,
+        userId: m.userId,
+        relation: m.relation
+      };
+      if (traceparent) {
+        payload.traceparent = traceparent;
+      }
+      await app.di.outboxRepo.enqueue({
+        aggregateType: 'membership',
+        aggregateId: m.id,
+        type: 'membership.added',
+        payload
+      });
+      return reply.code(201).send({ id: m.id, unitId: m.unitId, relation: m.relation });
     });
-    const active = await membershipRepo.countActive();
-    membershipActiveGauge.set(active);
-    await app.di.outboxRepo.enqueue({
-      aggregateType: 'membership',
-      aggregateId: m.id,
-      type: 'membership.added',
-      payload: { id: m.id, unitId: m.unitId, userId: m.userId, relation: m.relation }
-    });
-    return reply.code(201).send({ id: m.id, unitId: m.unitId, relation: m.relation });
   });
 }

--- a/apps/services/tenant-service/internal/adapters/http/routes/tenants.ts
+++ b/apps/services/tenant-service/internal/adapters/http/routes/tenants.ts
@@ -1,7 +1,8 @@
 import { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { tenantCreatedTotal } from '../../../metrics/registry.js';
-import { trace } from '@opentelemetry/api';
+import { withSpan } from '@smartedify/shared/tracing';
+import { getActiveTraceparent } from '../../../observability/trace-context.js';
 
 const createTenantSchema = z.object({
   name: z.string().min(1),
@@ -12,30 +13,39 @@ const createTenantSchema = z.object({
 type CreateTenantBody = ReturnType<typeof createTenantSchema.parse>;
 interface GetTenantParams { id: string }
 
+const TENANT_TRACER = process.env.TENANT_SERVICE_NAME || 'tenant-service';
+
 export async function tenantRoutes(app: FastifyInstance) {
   const repo = app.di.tenantRepo;
   app.post('/tenants', async (req: FastifyRequest<{ Body: unknown }>, reply) => {
-    const parsed = createTenantSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return reply.status(400).send({ error: 'validation_error', details: parsed.error.flatten() });
-    }
-    const body: CreateTenantBody = parsed.data;
-    const t = await repo.create(body);
-    tenantCreatedTotal.inc();
-    const span = trace.getActiveSpan();
-    if (span) {
+    return withSpan(TENANT_TRACER, 'tenant.create', undefined, async span => {
+      const parsed = createTenantSchema.safeParse(req.body);
+      if (!parsed.success) {
+        span.setAttribute('tenant.result', 'validation_error');
+        return reply.status(400).send({ error: 'validation_error', details: parsed.error.flatten() });
+      }
+      const body: CreateTenantBody = parsed.data;
+      const t = await repo.create(body);
+      tenantCreatedTotal.inc();
       span.setAttribute('tenant.id', t.id);
       if (t.code) {
         span.setAttribute('tenant.code', t.code);
       }
-    }
-    await app.di.outboxRepo.enqueue({
-      aggregateType: 'tenant',
-      aggregateId: t.id,
-      type: 'tenant.created',
-      payload: { id: t.id, name: t.name, code: t.code }
+      span.setAttribute('tenant.result', 'success');
+      span.addEvent('tenant.created', { 'tenant.id': t.id });
+      const traceparent = getActiveTraceparent();
+      const payload: Record<string, unknown> = { id: t.id, name: t.name, code: t.code };
+      if (traceparent) {
+        payload.traceparent = traceparent;
+      }
+      await app.di.outboxRepo.enqueue({
+        aggregateType: 'tenant',
+        aggregateId: t.id,
+        type: 'tenant.created',
+        payload
+      });
+      return reply.code(201).send({ id: t.id, name: t.name, code: t.code, timezone: t.timezone, status: t.status });
     });
-    return reply.code(201).send({ id: t.id, name: t.name, code: t.code, timezone: t.timezone, status: t.status });
   });
 
   app.get('/tenants/:id', async (req: FastifyRequest<{ Params: GetTenantParams }>, reply) => {

--- a/apps/services/tenant-service/internal/adapters/http/routes/units.ts
+++ b/apps/services/tenant-service/internal/adapters/http/routes/units.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { unitCreatedTotal } from '../../../metrics/registry.js';
+import { withSpan } from '@smartedify/shared/tracing';
+import { getActiveTraceparent } from '../../../observability/trace-context.js';
 
 const createUnitSchema = z.object({
   code: z.string().min(1),
@@ -9,22 +11,49 @@ const createUnitSchema = z.object({
   areaM2: z.number().positive().optional()
 });
 
+const TENANT_TRACER = process.env.TENANT_SERVICE_NAME || 'tenant-service';
+
 export async function unitRoutes(app: FastifyInstance) {
   const unitRepo = app.di.unitRepo;
   app.post('/tenants/:tenantId/units', async (req, reply) => {
     // @ts-ignore simplifying
     const { tenantId } = req.params;
-    const bodyParse = createUnitSchema.safeParse(req.body);
-    if (!bodyParse.success) return reply.status(400).send({ error: 'validation_error', details: bodyParse.error.flatten() });
-    const unit = await unitRepo.create({ tenantId, code: bodyParse.data.code, type: bodyParse.data.type, parentUnitId: bodyParse.data.parentUnitId, areaM2: bodyParse.data.areaM2 });
-    unitCreatedTotal.inc();
-    await app.di.outboxRepo.enqueue({
-      aggregateType: 'unit',
-      aggregateId: unit.id,
-      type: 'unit.created',
-      payload: { id: unit.id, tenantId: unit.tenantId, code: unit.code, type: unit.type }
+    return withSpan(TENANT_TRACER, 'tenant.unit.create', { 'tenant.id': tenantId }, async span => {
+      const bodyParse = createUnitSchema.safeParse(req.body);
+      if (!bodyParse.success) {
+        span.setAttribute('unit.result', 'validation_error');
+        return reply.status(400).send({ error: 'validation_error', details: bodyParse.error.flatten() });
+      }
+      const unit = await unitRepo.create({
+        tenantId,
+        code: bodyParse.data.code,
+        type: bodyParse.data.type,
+        parentUnitId: bodyParse.data.parentUnitId,
+        areaM2: bodyParse.data.areaM2
+      });
+      unitCreatedTotal.inc();
+      span.setAttribute('unit.id', unit.id);
+      span.setAttribute('unit.code', unit.code);
+      span.setAttribute('unit.result', 'success');
+      span.addEvent('tenant.unit.created', { 'unit.id': unit.id, 'tenant.id': tenantId });
+      const traceparent = getActiveTraceparent();
+      const payload: Record<string, unknown> = {
+        id: unit.id,
+        tenantId: unit.tenantId,
+        code: unit.code,
+        type: unit.type
+      };
+      if (traceparent) {
+        payload.traceparent = traceparent;
+      }
+      await app.di.outboxRepo.enqueue({
+        aggregateType: 'unit',
+        aggregateId: unit.id,
+        type: 'unit.created',
+        payload
+      });
+      return reply.code(201).send({ id: unit.id, code: unit.code, type: unit.type, active: unit.active });
     });
-    return reply.code(201).send({ id: unit.id, code: unit.code, type: unit.type, active: unit.active });
   });
 
   app.get('/tenants/:tenantId/units', async (req) => {

--- a/apps/services/tenant-service/internal/observability/trace-context.ts
+++ b/apps/services/tenant-service/internal/observability/trace-context.ts
@@ -1,0 +1,12 @@
+import { context, trace } from '@opentelemetry/api';
+
+export function getActiveTraceparent(): string | null {
+  const span = trace.getSpan(context.active());
+  if (!span) return null;
+  const spanContext = span.spanContext();
+  if (!spanContext.traceId || !spanContext.spanId) {
+    return null;
+  }
+  const flags = spanContext.traceFlags.toString(16).padStart(2, '0');
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${flags}`;
+}

--- a/docs/design/diagrams/tracing-span-map.mmd
+++ b/docs/design/diagrams/tracing-span-map.mmd
@@ -1,0 +1,43 @@
+---
+title: SmartEdify - Tracing Span Map (Auth & Tenant)
+---
+flowchart TD
+    subgraph Auth[Auth Service]
+        A1[POST /login] --> S1[auth.login]
+        S1 --> E1[[Events<br/>login.success / login.failure]]
+        S1 --> Attr1[[Attributes<br/>auth.tenant_id<br/>auth.user_id<br/>auth.result]]
+        S1 --> M1[[Metrics<br/>login_success_total / login_fail_total]]
+
+        A2[POST /register] --> S2[auth.register]
+        S2 --> Attr2[[Attributes<br/>auth.tenant_id<br/>auth.user_id<br/>auth.result]]
+
+        A3[POST /refresh-token] --> S3[auth.refresh]
+        S3 --> E3[[Events<br/>refresh.success / refresh.failure]]
+        S3 --> Attr3[[Attributes<br/>auth.tenant_id<br/>auth.user_id<br/>auth.result]]
+
+        A4[POST /admin/rotate-keys] --> S4[auth.admin.rotate-keys]
+        S4 --> Attr4[[Attributes<br/>auth.result<br/>jwks.current_kid<br/>jwks.next_kid?]]
+        S4 --> E4[[Events<br/>admin.rotate.success / admin.rotate.failure]]
+
+        A5[POST /admin/revoke-kid] --> S5[auth.admin.revoke-kid]
+        S5 --> Attr5[[Attributes<br/>auth.result<br/>auth.kid]]
+        S5 --> E5[[Events<br/>admin.revoke.success / admin.revoke.failure]]
+    end
+
+    subgraph Tenant[Tenant Service]
+        T1[POST /tenants] --> TS1[tenant.create]
+        TS1 --> AttrT1[[Attributes<br/>tenant.id<br/>tenant.code<br/>tenant.result]]
+        TS1 --> OT1[(Outbox tenant.created<br/>payload.traceparent)]
+
+        T2[POST /tenants/:id/units] --> TS2[tenant.unit.create]
+        TS2 --> AttrT2[[Attributes<br/>tenant.id<br/>unit.id<br/>unit.code<br/>unit.result]]
+        TS2 --> OT2[(Outbox unit.created<br/>payload.traceparent)]
+
+        T3[POST /units/:unitId/memberships] --> TS3[tenant.membership.create]
+        TS3 --> AttrT3[[Attributes<br/>unit.id<br/>membership.id<br/>membership.user_id<br/>membership.result]]
+        TS3 --> OT3[(Outbox membership.added<br/>payload.traceparent)]
+    end
+
+    TS1 -->|traceparent| OT1
+    TS2 -->|traceparent| OT2
+    TS3 -->|traceparent| OT3

--- a/packages/shared/src/tracing/index.ts
+++ b/packages/shared/src/tracing/index.ts
@@ -1,1 +1,2 @@
 export * from './node-tracing.js';
+export * from './with-span.js';

--- a/packages/shared/src/tracing/with-span.ts
+++ b/packages/shared/src/tracing/with-span.ts
@@ -1,0 +1,45 @@
+import { context, trace, SpanStatusCode, type Span, type SpanAttributes } from '@opentelemetry/api';
+
+export type SpanCallback<T> = (span: Span) => Promise<T> | T;
+
+export async function withSpan<T>(
+  tracerName: string,
+  spanName: string,
+  attributes: SpanAttributes | undefined,
+  fn: SpanCallback<T>
+): Promise<T>;
+export async function withSpan<T>(tracerName: string, spanName: string, fn: SpanCallback<T>): Promise<T>;
+export async function withSpan<T>(
+  tracerName: string,
+  spanName: string,
+  attributesOrFn: SpanAttributes | SpanCallback<T> | undefined,
+  maybeFn?: SpanCallback<T>
+): Promise<T> {
+  const tracer = trace.getTracer(tracerName);
+  const span = tracer.startSpan(spanName, undefined, context.active());
+  const ctx = trace.setSpan(context.active(), span);
+  const attributes = typeof attributesOrFn === 'function' ? undefined : attributesOrFn;
+  const fn = (typeof attributesOrFn === 'function' ? attributesOrFn : maybeFn) as SpanCallback<T>;
+
+  if (!fn) {
+    span.end();
+    throw new Error('withSpan requires a callback');
+  }
+
+  if (attributes) {
+    span.setAttributes(attributes);
+  }
+
+  try {
+    const result = await context.with(ctx, async () => fn(span));
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
+    span.recordException(error as any);
+    throw error;
+  } finally {
+    span.end();
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `withSpan` helper in `@smartedify/shared` to execute logic inside OpenTelemetry spans
- wrap auth login/register/refresh handlers and admin endpoints with spans that enrich events and metrics attributes
- instrument tenant creation/unit/membership flows with spans, propagate `traceparent` into outbox payloads, and document the updated span map

## Testing
- `npm run test:proj:unit` *(fails: jest binary unavailable before install)*
- `npm run test:unit` *(fails: cross-env/vitest unavailable before install)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcda64c6c8329b8daed362436be7d