### PR TITLE
docs: document observability dashboards and daily ops

### DIFF
--- a/docs/observability/alerting-checklist.md
+++ b/docs/observability/alerting-checklist.md
@@ -1,75 +1,52 @@
-# Checklist de Alertas SRE – SmartEdify (Inicial)
+# Checklist de Alertas SRE – SmartEdify
 
-Estado: Draft inicial (enfocado en Tenant Service + Outbox/Consumer)  
-Última actualización: 2025-09-14
+Estado: Activo (Auth + Tenant)
+Última actualización: 2025-09-24
 
 ## Objetivos
-Proveer un set mínimo de alertas accionables que cubran: disponibilidad de pipeline de eventos, latencia de procesamiento, crecimiento anómalo de backlog y calidad de handlers.
+Garantizar que cada alerta crítica tenga tablero, procedimiento y responsables claros, cubriendo disponibilidad del pipeline de eventos, experiencia de login y abuso de credenciales.
 
 ## Convenciones
-- Prefijo de métricas ya en uso (Prometheus): `outbox_`, `consumer_`, `broker_consumer_`.
-- Reglas escritas para Prometheus + Alertmanager.
-- Duraciones iniciales conservadoras (evitan ruido en early stage). Ajustar tras 2 semanas de observación.
+- Métricas Prometheus prefijadas: `auth_`, `outbox_`, `consumer_`, `broker_consumer_`.
+- Todas las reglas viven en el grupo `smartedify-core-services` y se sincronizan via GitOps.
+- Cada alerta exige captura o enlace al dashboard exportado correspondiente como evidencia en el ticket de incidente.
+
+## Tableros publicados
+- **Auth Service · Negocio y SLO** → [export JSON](./dashboards/auth-service.json) (carpeta Grafana `SmartEdify / Core Services`). Filtros: `environment` (obligatorio), `tenant` (multi-select, opción `All`).
+- **Tenant Service · Outbox & Consumers** → [export JSON](./dashboards/tenant-service.json). Filtros: `environment` (obligatorio), `consumer` (`tenant-consumer` por defecto).
 
 ## Tabla Resumen
-| Dominio | Métrica / Regla | Objetivo | Severidad | Acción sugerida |
-|---------|-----------------|----------|-----------|-----------------|
-| Backlog | `broker_consumer_lag_max > 10000 for 5m` | Evitar saturación | P1 | Verificar disponibilidad handlers / throttling broker |
-| Backlog | `increase(broker_consumer_lag_max[10m]) > 20000` | Crecimiento acelerado | P2 | Escalar consumidores / investigar stuck partition |
-| Éxito | `rate(consumer_events_processed_total{status="error"}[15m]) / rate(consumer_events_processed_total[15m]) > 0.02` | Error ratio <2% | P2 | Revisar top eventTypes fallando |
-| Retries | `rate(consumer_retry_attempts_total[10m]) > 50` | Retries controlados | P3 | Verificar dependencias externas (DB, APIs) |
-| Latencia | `histogram_quantile(0.95, sum(rate(consumer_process_duration_seconds_bucket[5m])) by (le)) > 0.5` | p95 < 500ms | P2 | Perf profiling handler lento |
-| Outbox | `rate(outbox_failed_total[10m]) > 0` AND `rate(outbox_published_total[10m]) == 0` | Publicación detenida | P1 | Revisar publisher / credenciales broker |
-| Outbox | `outbox_pending > 2000` | Evitar cola grande | P2 | Verificar poller frecuencia / locks DB |
-| DLQ | `outbox_dlq_size > 0` | DLQ vacío esperado | P3 | Reprocesar / abrir ticket dominio |
-| Handler Missing | `increase(consumer_handler_not_found_total[15m]) > 0` | Config sync | P3 | Registrar handler o filtrar evento desconocido |
-| Infra | `up{job="tenant-service"} == 0` | Disponibilidad | P1 | Reiniciar / investigar crash loop |
+| Dominio | Métrica / Regla | Objetivo | Severidad | Acción sugerida | Dashboard | Runbook |
+|---------|-----------------|----------|-----------|-----------------|-----------|---------|
+| Auth | `histogram_quantile(0.95, sum(rate(auth_http_request_duration_seconds_bucket{route="/login"}[5m])) by (le)) > 0.25` durante 15m | p95 < 250ms | P1 | Revisar despliegues, dependencia IdP | Auth Service · Negocio y SLO (panel *Latency p95 /login*) | [`auth-login-latency.md`](../runbooks/auth-login-latency.md) |
+| Auth | `rate(auth_login_success_total[5m]) / (rate(auth_login_success_total[5m]) + rate(auth_login_fail_total[5m])) < 0.92` durante 20m | ≥ 92% | P1/P0 si <0.85 | Analizar caída por tenant, activar feature flag de degradación | Auth Service · Negocio y SLO (panel *Login success ratio*) | [`auth-login-latency.md`](../runbooks/auth-login-latency.md) |
+| Auth | `increase(auth_refresh_reuse_blocked_total[5m]) > 0` | 0 reuse detectado | P0 | Bloquear tenant, rotar claves | Auth Service · Negocio y SLO (panel *Token revocations & reuse*) | [`auth-login-latency.md`](../runbooks/auth-login-latency.md) |
+| Backlog | `broker_consumer_lag_max > 10000 for 5m` | Lag < 10k | P1 | Escalar réplicas / throughput | Tenant Service · Outbox & Consumers (panel *Lag consumidor*) | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Backlog | `increase(broker_consumer_lag_max[10m]) > 20000` | Crecimiento controlado | P2 | Investigar partición bloqueada | Tenant Service · Outbox & Consumers | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Éxito | `rate(consumer_events_processed_total{status="error"}[15m]) / rate(consumer_events_processed_total[15m]) > 0.02` | Error ratio <2% | P2 | Revisar eventType con error | Tenant Service · Outbox & Consumers (panel *Procesamiento de eventos*) | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Retries | `rate(consumer_retry_attempts_total[10m]) > 50` | Retries controlados | P3 | Revisar dependencias externas | Tenant Service · Outbox & Consumers | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Latencia | `histogram_quantile(0.95, sum(rate(consumer_process_duration_seconds_bucket[5m])) by (le)) > 0.5` | p95 < 500ms | P2 | Profiling handler lento | Tenant Service · Outbox & Consumers (panel *Latencia p95 consumidor*) | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Outbox | `rate(outbox_failed_total[10m]) > 0` AND `rate(outbox_published_total[10m]) == 0` | Publicación continua | P1 | Revisar publisher / credenciales broker | Tenant Service · Outbox & Consumers (panel *Estado de outbox*) | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Outbox | `outbox_pending > 2000` | Cola controlada | P2 | Ajustar poll interval / locks | Tenant Service · Outbox & Consumers | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| DLQ | `outbox_dlq_size > 0` | DLQ vacío | P3 | Ejecutar reprocesamiento | Tenant Service · Outbox & Consumers (tabla *Eventos DLQ por tipo*) | [`dlq-reprocessing.md`](../runbooks/dlq-reprocessing.md) |
+| Handler Missing | `increase(consumer_handler_not_found_total[15m]) > 0` | Config sincronizada | P3 | Registrar handler / filtrar evento | Tenant Service · Outbox & Consumers | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Infra | `up{job="tenant-service"} == 0` | Servicio activo | P1 | Reiniciar / investigar crash loop | Tenant Service · Outbox & Consumers (validar retorno de métricas) | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
 
-## Reglas Prometheus (ejemplos)
+## Reglas Prometheus (extracto)
 ```yaml
 groups:
-  - name: smartedify-event-pipeline
+  - name: smartedify-core-services
     interval: 30s
     rules:
-      - alert: ConsumerBacklogHigh
-        expr: broker_consumer_lag_max > 10000
-        for: 5m
-        labels:
-          severity: critical
-          service: tenant-service
-        annotations:
-          summary: "Lag elevado en consumidor"
-          description: "Lag máximo {{ $value }} > 10k durante 5m. Posible cuello de botella en handlers o caída de instancias."
-
-      - alert: ConsumerErrorRatioHigh
-        expr: (rate(consumer_events_processed_total{status="error"}[15m]) / rate(consumer_events_processed_total[15m])) > 0.02
-        for: 10m
-        labels:
-          severity: warning
-          service: tenant-service
-        annotations:
-          summary: "Ratio de errores >2%"
-          description: "Error ratio sostenido. Revisar logs de handlers más frecuentes."
-
-      - alert: ConsumerRetriesSurge
-        expr: rate(consumer_retry_attempts_total[10m]) > 50
-        for: 10m
-        labels:
-          severity: warning
-          service: tenant-service
-        annotations:
-          summary: "Aumento inusual de retries"
-          description: "Posibles fallos intermitentes dependencias externas. Investigar latencias y status codes."
-
-      - alert: ConsumerLatencyP95Degraded
-        expr: histogram_quantile(0.95, sum(rate(consumer_process_duration_seconds_bucket[5m])) by (le)) > 0.5
+      - alert: AuthLoginLatencyP95Degraded
+        expr: histogram_quantile(0.95, sum(rate(auth_http_request_duration_seconds_bucket{route="/login",status="200"}[5m])) by (le)) > 0.25
         for: 15m
         labels:
-          severity: warning
-          service: tenant-service
+          severity: critical
+          service: auth-service
         annotations:
-          summary: "p95 procesamiento >500ms"
-          description: "Handlers lentos. Identificar eventType con mayor duración promedio."
+          summary: "Latencia p95 /login degradada"
+          runbook: "../runbooks/auth-login-latency.md"
 
       - alert: OutboxPublishingStalled
         expr: rate(outbox_published_total[10m]) == 0 and rate(outbox_failed_total[10m]) > 0
@@ -79,56 +56,29 @@ groups:
           service: tenant-service
         annotations:
           summary: "Publicación outbox detenida"
-          description: "Fallas sin publicaciones exitosas recientes. Revisar credenciales broker o saturación DB."
-
-      - alert: OutboxPendingBacklog
-        expr: outbox_pending > 2000
-        for: 15m
-        labels:
-          severity: warning
-          service: tenant-service
-        annotations:
-          summary: "Outbox pending elevado"
-          description: "La cola pending supera 2000. Ajustar poll interval o escalar servicio."
-
-      - alert: DLQNotEmpty
-        expr: outbox_dlq_size > 0
-        for: 30m
-        labels:
-          severity: info
-          service: tenant-service
-        annotations:
-          summary: "Eventos en DLQ"
-          description: "Existen eventos en DLQ. Revisar y reprocesar si procede."
-
-      - alert: HandlerMissingEvents
-        expr: increase(consumer_handler_not_found_total[15m]) > 0
-        for: 15m
-        labels:
-          severity: info
-          service: tenant-service
-        annotations:
-          summary: "Eventos sin handler"
-          description: "Se recibieron eventos sin handler registrado. Confirmar despliegues coordinados."
+          runbook: "../runbooks/tenant-consumer-lag.md"
 ```
 
 ## Runbook (resumen de acciones)
-| Alerta | Diagnóstico rápido | Acción 1 | Acción 2 | Escalado |
-|--------|--------------------|----------|----------|----------|
-| ConsumerBacklogHigh | Verificar CPU/heap, métricas inflight | Escalar réplicas | Aumentar max concurrency (si seguro) | Equipo backend |
-| ConsumerErrorRatioHigh | Inspeccionar logs por eventType | Deshabilitar handler defectuoso temporalmente | Hotfix / rollback | Equipo dominio + backend |
-| ConsumerRetriesSurge | Identificar dependencia (DB/API) latente | Revisar latencias infra | Activar fallback/circuit breaker | Infra/SRE |
-| ConsumerLatencyP95Degraded | Identificar top N handlers lentos | Profiling (flamegraph) | Optimizar consultas / caché | Backend |
-| OutboxPublishingStalled | Verificar conectividad broker | Reiniciar publisher | Rotar credenciales / failover | Infra/SRE |
-| OutboxPendingBacklog | Revisar locks DB y poll interval | Escalar poller | Particionar workload | Infra + Backend |
-| DLQNotEmpty | Consultar `/outbox/dlq` | Reprocesar selectivamente | Abrir ticket análisis | Dominio |
-| HandlerMissingEvents | Confirmar naming eventType | Deploy handler faltante | Filtrar en source | Backend |
+| Alerta | Diagnóstico rápido (dashboard) | Acción 1 | Acción 2 | Evidencia requerida | Escalado |
+|--------|-------------------------------|----------|----------|--------------------|----------|
+| AuthLoginLatencyP95Degraded | Captura panel *Latency p95 /login* filtrado por `environment` | Revisar despliegues últimos 30m | Rollback si persiste >2 ventanas | Screenshot + query PromQL | Equipo Auth + On-call |
+| AuthLoginSuccessDrop | Panel *Login success ratio* + breakdown por `tenant` | Revisar feature flags / dependencias | Activar modo degradado (`AUTH_LOGIN_GUARDIAN`) | Tabla de tenants afectados | Equipo Auth + Producto |
+| AuthRefreshReuseDetected | Panel *Token revocations & reuse* | Bloquear tenant y revocar tokens | Coordinar rotación clave | Export CSV `auth_refresh_reuse_blocked_total` | Seguridad + Auth |
+| ConsumerBacklogHigh | Panel *Lag consumidor* + logs `tenant-consumer` | Escalar réplicas / throughput | Ejecutar [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) | Screenshot + `broker_consumer_lag_max` | Equipo Tenant + SRE |
+| ConsumerErrorRatioHigh | Panel *Procesamiento de eventos* (split status) | Identificar eventType con error | Deshabilitar handler / parchear | Lista de eventTypes top | Equipo Tenant + Dominio |
+| ConsumerLatencyP95Degraded | Panel *Latencia p95 consumidor* | Identificar handler lento | Optimizar consultas / caches | Antes/después del panel | Backend |
+| OutboxPublishingStalled | Panel *Estado de outbox* + logs publisher | Revisar conectividad broker | Rotar credenciales / failover | Métricas `outbox_failed_total` post-fix | Infra/SRE |
+| OutboxPendingBacklog | Panel *Estado de outbox* | Ajustar poll interval | Escalar poller horizontal | Gráfico `outbox_pending` < umbral | Infra + Backend |
+| DLQNotEmpty | Tabla *Eventos DLQ por tipo* | Ejecutar [`dlq-reprocessing.md`](../runbooks/dlq-reprocessing.md) | Escalar a dominio si causa abierta | Snapshot + CSV | Dominio |
+| HandlerMissingEvents | Panel *Procesamiento de eventos* | Registrar handler faltante | Coordinar despliegue | Log del evento desconocido | Backend |
+| InfraDown | Paneles sin datos + `up{job="tenant-service"}` | Ejecutar smoke `/healthz` | Reiniciar / escalar a plataforma | `kubectl get pods` adjunto | SRE |
 
 ## Próximas Iteraciones
-- Añadir alertas de saturación GC / heap.
-- Integrar tracing para correlacionar p95 con spans lentos.
-- Ajustar thresholds con percentiles históricos reales.
-- Añadir alerta sobre ratio de reprocess DLQ fallidos.
+- Añadir alerta de saturación GC/heap (`process_resident_memory_bytes`).
+- Integrar tracing → correlacionar paneles p95 con spans en Tempo (Auth y Tenant).
+- Ajustar thresholds con percentiles históricos exportados.
+- Publicar checklist automática post-incident en Notion (sincroniza con este documento).
 
 ---
 Este documento evolucionará conforme crezca el volumen y complejidad del tráfico.

--- a/docs/observability/dashboards/auth-service.json
+++ b/docs/observability/dashboards/auth-service.json
@@ -1,0 +1,211 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(auth_login_success_total{environment=~\"$environment\",tenant_id=~\"$tenant\"}[5m]) / (rate(auth_login_success_total{environment=~\"$environment\",tenant_id=~\"$tenant\"}[5m]) + rate(auth_login_fail_total{environment=~\"$environment\",tenant_id=~\"$tenant\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Success ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Login success ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(auth_http_request_duration_seconds_bucket{route=\"/login\",environment=~\"$environment\",tenant_id=~\"$tenant\"}[5m])) by (le)) * 1000",
+          "legendFormat": "p95 /login",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95 /login",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "table"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(auth_refresh_reuse_blocked_total{environment=~\"$environment\",tenant_id=~\"$tenant\"}[5m])",
+          "legendFormat": "Blocked reuse",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(auth_token_revoked_total{environment=~\"$environment\",type=\"access\",tenant_id=~\"$tenant\"}[5m])",
+          "legendFormat": "Access revoked",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(auth_token_revoked_total{environment=~\"$environment\",type=\"refresh\",tenant_id=~\"$tenant\"}[5m])",
+          "legendFormat": "Refresh revoked",
+          "refId": "C"
+        }
+      ],
+      "title": "Token revocations & reuse",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo-main"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "query": {
+          "query": "{service.name=\"auth-service\", auth.tenant_id=~\"$tenant\"} | unwrap duration | avg()"
+        },
+        "showTable": false
+      },
+      "title": "Trace duration (average)",
+      "type": "tempo-topology"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "auth-service",
+    "slo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "production",
+          "value": "production"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prom-main"
+        },
+        "definition": "label_values(auth_login_success_total, environment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "query": "label_values(auth_login_success_total, environment)",
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "/.*/"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prom-main"
+        },
+        "definition": "label_values(auth_login_success_total, tenant_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tenant",
+        "multi": true,
+        "name": "tenant",
+        "query": "label_values(auth_login_success_total, tenant_id)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "",
+  "title": "Auth Service · Negocio y SLO",
+  "uid": "auth-business-slo",
+  "version": 3
+}

--- a/docs/observability/dashboards/tenant-service.json
+++ b/docs/observability/dashboards/tenant-service.json
@@ -1,0 +1,229 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Pipeline de eventos (outbox + consumer) del Tenant Service.",
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "table"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(broker_consumer_lag_max{consumer_group=~\"$consumer\",environment=~\"$environment\"})",
+          "legendFormat": "Max lag",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(broker_consumer_lag_sum{consumer_group=~\"$consumer\",environment=~\"$environment\"})",
+          "legendFormat": "Lag sum",
+          "refId": "B"
+        }
+      ],
+      "title": "Lag consumidor",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "table"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(consumer_events_processed_total{status=\"error\",consumer_group=~\"$consumer\",environment=~\"$environment\"}[5m])",
+          "legendFormat": "Errores",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(consumer_events_processed_total{status=\"success\",consumer_group=~\"$consumer\",environment=~\"$environment\"}[5m])",
+          "legendFormat": "Éxitos",
+          "refId": "B"
+        }
+      ],
+      "title": "Procesamiento de eventos",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "outbox_pending{environment=~\"$environment\"}",
+          "legendFormat": "Pending",
+          "refId": "A"
+        },
+        {
+          "expr": "outbox_ready{environment=~\"$environment\"}",
+          "legendFormat": "Ready",
+          "refId": "B"
+        },
+        {
+          "expr": "outbox_failed{environment=~\"$environment\"}",
+          "legendFormat": "Failed",
+          "refId": "C"
+        }
+      ],
+      "title": "Estado de outbox",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(consumer_process_duration_seconds_bucket{consumer_group=~\"$consumer\",environment=~\"$environment\"}[5m])) by (le))",
+          "legendFormat": "p95 procesamiento",
+          "refId": "A"
+        }
+      ],
+      "title": "Latencia p95 consumidor",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prom-main"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 14,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "sum by (type) (increase(outbox_dlq_events_total{environment=~\"$environment\"}[1h]))",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Eventos DLQ por tipo (última hora)",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": [
+    "tenant-service",
+    "pipeline"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "production",
+          "value": "production"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prom-main"
+        },
+        "definition": "label_values(outbox_pending, environment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "query": "label_values(outbox_pending, environment)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "tenant-consumer",
+          "value": "tenant-consumer"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prom-main"
+        },
+        "definition": "label_values(consumer_events_processed_total, consumer_group)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Consumer group",
+        "multi": false,
+        "name": "consumer",
+        "query": "label_values(consumer_events_processed_total, consumer_group)",
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timezone": "",
+  "title": "Tenant Service · Outbox & Consumers",
+  "uid": "tenant-outbox-consumers",
+  "version": 5
+}

--- a/docs/operations/ci-cd.md
+++ b/docs/operations/ci-cd.md
@@ -146,12 +146,15 @@ Para reproducir los gates principales localmente:
   - Re-ejecutar suites unit/contract en el commit revertido.
 
 ## Validación post-despliegue
-- SLI/SLO por servicio. Alertas: error rate, p95, 5xx, *consumer lag*, DLQ > umbral.
+- SLI/SLO por servicio. Alertas: error rate, p95, 5xx, *consumer lag*, DLQ > umbral (ver [`docs/operations/daily-operations.md`](./daily-operations.md) para checklist detallado).
 - Validar que no existan nuevas alertas críticas en los dashboards durante al menos 15 minutos tras el despliegue.
 - Ejecutar pruebas de smoke test:
   ```bash
   ./scripts/smoke-test.sh --service <nombre>
   ```
+
+## Operación diaria
+Las rondas operativas (AM/PM) y cron jobs asociados a Auth/Tenant están descritos en [`docs/operations/daily-operations.md`](./daily-operations.md). Cualquier promoción debe actualizar evidencias en esa bitácora para mantener la trazabilidad ejecutiva.
 
 ## Contactos
 - **On-call Plataforma:** `#oncall-plataforma` / oncall@smartedify.com

--- a/docs/operations/daily-operations.md
+++ b/docs/operations/daily-operations.md
@@ -1,0 +1,55 @@
+# Operación diaria – Core Services
+
+> **Propósito:** Consolidar los chequeos rutinarios (manuales y automatizados) que garantizan salud operativa en Auth y Tenant Service.
+> **Alcance:** producción y staging.
+
+## Rondas AM (08:00 UTC)
+| Paso | Responsable | Herramienta | Evidencia |
+|------|-------------|-------------|-----------|
+| Validar tableros SLO | On-call Plataforma | Grafana (`Auth Service · Negocio y SLO`, `Tenant Service · Outbox & Consumers`) | Screenshot almacenado en `ops-daily/YYYY-MM-DD/` |
+| Revisar alertas nocturnas | On-call Plataforma | Alertmanager / PagerDuty | Resumen en `#oncall-plataforma` |
+| Confirmar jobs cron | Observabilidad | `kubectl get cronjobs -n ops` (`auth-slo-canary`, `tenant-outbox-sweeper`, `tenant-consumer-lag-report`) | Output guardado en ticket diario |
+| Checar backlog DLQ | Tenant Core | Dashboard tabla *Eventos DLQ por tipo* + `outbox_dlq_size` | Comentario en Jira `OPS-DAILY` |
+
+## Rondas PM (18:00 UTC)
+1. **Auth Service**
+   - Revisar panel *Token revocations & reuse* buscando spikes.
+   - Verificar que job `auth-slo-canary` adjuntó screenshot en `#auth-observability`.
+   - Ejecutar validación rápida:
+     ```bash
+     kubectl -n monitoring exec deploy/prometheus -- promtool query instant http://localhost:9090 \
+       "histogram_quantile(0.95, sum(rate(auth_http_request_duration_seconds_bucket{route='/login',environment='production'}[5m])) by (le))"
+     ```
+   - Si valores fuera de rango → seguir [`auth-login-latency.md`](../runbooks/auth-login-latency.md).
+2. **Tenant Service**
+   - Panel *Lag consumidor* < 5 000 en últimas 3 ventanas; registrar valor en `ops-daily`.
+   - Confirmar ejecución cron `tenant-outbox-sweeper` (`kubectl logs job/<name> -n tenants | tail`).
+   - Revisar `outbox_pending` y `outbox_failed` desde dashboard; si > 1 000 o >0 respectivamente activar [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) o [`dlq-reprocessing.md`](../runbooks/dlq-reprocessing.md).
+
+## Post-deploy checklist (aplica a cada promoción)
+| Servicio | Paso | Responsable | Documento |
+|----------|------|-------------|-----------|
+| Auth | Confirmar panel *Latency p95 /login* < 250 ms (15 min) | Equipo Auth | [`auth-login-latency.md`](../runbooks/auth-login-latency.md) |
+| Auth | Validar reuse rate == 0 tras despliegue | Seguridad | [`auth-login-latency.md`](../runbooks/auth-login-latency.md) |
+| Tenant | Panel *Lag consumidor* estable (sin pendiente positiva) | Tenant Core | [`tenant-consumer-lag.md`](../runbooks/tenant-consumer-lag.md) |
+| Tenant | DLQ sin crecimiento (>10) | Tenant Core | [`dlq-reprocessing.md`](../runbooks/dlq-reprocessing.md) |
+
+## Registro y trazabilidad
+- Guardar todas las evidencias (capturas, outputs de comandos) en la carpeta `ops-daily/YYYY/MM-DD` dentro de SharePoint.
+- Actualizar el snapshot ejecutivo (`docs/status.md`) si:
+  - Se consumió >15 % del error budget de un SLO.
+  - Un cron job falló más de dos veces consecutivas.
+  - Se ejecutó un runbook completo.
+- Registrar aprendizajes y ajustes pendientes en `task.md` bajo la sección "Operación diaria".
+
+## Automatizaciones
+- `auth-slo-canary` (cron horario): exporta métricas PromQL y captura del dashboard; falla → abre ticket `OBS-AUTH-<fecha>`.
+- `tenant-outbox-sweeper` (cron 15 min): genera CSV de eventos DLQ y alerta si `outbox_dlq_size > 0` por 3 ejecuciones.
+- `tenant-consumer-lag-report` (cron 5 min): compara `broker_consumer_lag_max` vs umbral y emite alerta proactiva antes de `ConsumerBacklogHigh`.
+
+## Escalamiento
+- Falta de evidencia en una ronda → notificar inmediatamente a `Head of Platform` y registrar en `#oncall-plataforma`.
+- Dos fallas consecutivas de cron job → abrir incidente P2 y programar revisión de confiabilidad.
+
+---
+Mantener este documento sincronizado con actualizaciones en dashboards o cron jobs para conservar trazabilidad ejecutiva.

--- a/docs/runbooks/auth-login-latency.md
+++ b/docs/runbooks/auth-login-latency.md
@@ -1,0 +1,62 @@
+# Runbook — Degradación de login Auth Service
+
+> **Dashboards**
+> - [`Auth Service · Negocio y SLO`](../observability/dashboards/auth-service.json)
+> - Paneles clave: *Latency p95 /login*, *Login success ratio*, *Token revocations & reuse*
+>
+> **Alertas cubiertas:** `AuthLoginLatencyP95Degraded`, `AuthLoginSuccessDrop`, `AuthRefreshReuseDetected`
+> **Contacto:** `#oncall-plataforma`, `auth-core@smartedify.com`, `security@smartedify.com`
+
+## Preconditions
+- Alerta activa en PagerDuty o en Slack `#obs-alerts`.
+- Acceso a Grafana (folder `SmartEdify / Core Services`).
+- Acceso a métricas Prometheus (`kubectl port-forward` o VPN) para ejecutar consultas ad-hoc.
+- Verificar últimas implementaciones (`scripts/deploy.sh --history auth-service`).
+
+## Diagnóstico inicial (5 minutos)
+1. **Capturar tablero.** Filtra el dashboard por `environment` y, si aplica, selecciona los tenants reportados en la alerta.
+   - Exporta screenshot de los paneles *Latency p95 /login* y *Login success ratio*.
+   - Adjunta la URL del panel específico (Grafana genera permalinks) en el ticket.
+2. **Confirmar en PromQL.**
+   ```bash
+   # Latencia p95 (ms)
+   kubectl -n monitoring exec deploy/prometheus -- \
+     promtool query instant http://localhost:9090 \
+     "histogram_quantile(0.95, sum(rate(auth_http_request_duration_seconds_bucket{route='/login',environment='production'}[5m])) by (le)) * 1000"
+   ```
+   - Repite con `tenant_id` sospechoso para aislar la degradación.
+3. **Revisar distribución de códigos.**
+   ```bash
+   kubectl logs deploy/auth-service -n auth --since=10m | grep "POST /login" | jq '.status' | sort | uniq -c
+   ```
+4. **Verificar dependencias externas (IdP / DB).** Comprueba latencias en `Auth Service · Salud técnica` si procede.
+
+## Contención
+- **Latencia degradada:**
+  1. Desactivar experimentos o features recientes (`AUTH_LOGIN_GUARDIAN`, `AUTH_RATE_LIMITER_BYPASS`).
+  2. Hacer rollback al último release estable:
+     ```bash
+     ./scripts/deploy.sh --service auth-service --environment production --ref <sha_estable>
+     ```
+  3. Forzar warmup ejecutando `./scripts/smoke-test.sh --service auth-service --environment production`.
+- **Caída de tasa de éxito:**
+  1. Identificar tenant afectado (`tenant_id` en panel y alerta) y activar `tenant:lock` vía feature flag service.
+  2. Escalar a producto si el impacto es >5 % usuarios.
+- **Detección de reuse:**
+  1. Revocar tokens del tenant comprometido (`POST /admin/tenants/{id}/tokens/revoke`).
+  2. Considerar rotación de clave si se sospecha filtración (ver `docs/operations/incident-auth-key-rotation.md`).
+
+## Validación
+- Confirmar que el panel *Latency p95 /login* vuelve < 250 ms y la tasa de éxito > 92 % durante al menos 3 ventanas consecutivas (15 minutos).
+- Ejecutar smoke tests (`./scripts/smoke-test.sh --service auth-service`) y adjuntar salida en ticket.
+- Registrar en el incidente la consulta PromQL final y los tenants desbloqueados.
+
+## Comunicación
+- Notificar resultado en `#oncall-plataforma` con resumen (impacto, causa raíz, acciones).
+- Actualizar `docs/status.md` si el incidente afecta indicadores ejecutivos.
+- Iniciar postmortem si el SLO consume >25 % de error budget.
+
+## Post-incident
+- Crear issue para automatizar mitigación (por ejemplo, ajuste de timeouts o circuit breakers).
+- Añadir aprendizaje en la sección *Operación diaria* (`docs/operations/daily-operations.md`).
+- Programar revisión de dashboards para asegurar que nuevos paneles reflejan la causa raíz.

--- a/docs/runbooks/dlq-reprocessing.md
+++ b/docs/runbooks/dlq-reprocessing.md
@@ -10,6 +10,7 @@ Restablecer el flujo de eventos movidos a la *dead letter queue* (DLQ) del Tenan
 ## Preconditions
 - Existe una alerta (`outbox_dlq_size > 0` o crecimiento acelerado) o un ticket operativo asignado.
 - Acceso a la base de datos del Tenant Service y permisos para invocar los endpoints `GET/POST/DELETE /outbox/dlq`.
+- Captura inicial del panel *Eventos DLQ por tipo* del dashboard [`Tenant Service · Outbox & Consumers`](../observability/dashboards/tenant-service.json) filtrado por `environment` correspondiente. Adjuntar screenshot en el ticket.
 - Snapshot inicial de la DLQ antes de cualquier acción.
 - Coordinación con el equipo de dominio afectado para validar que la causa raíz está mitigada.
 
@@ -21,6 +22,7 @@ Restablecer el flujo de eventos movidos a la *dead letter queue* (DLQ) del Tenan
    curl -s "$TENANT_API/outbox/dlq?limit=500" | jq '.' > dlq-snapshot.json
    ```
    - Métricas a observar: `outbox_dlq_size`, `outbox_event_age_seconds_bucket` (p95) y `outbox_reprocessed_total`.
+   - Adjunta en el ticket la captura previa del panel *Eventos DLQ por tipo (última hora)* filtrando por el mismo `environment`.
 
 2. **Agrupar eventos y detectar patrón.**
    ```sql
@@ -70,7 +72,7 @@ Restablecer el flujo de eventos movidos a la *dead letter queue* (DLQ) del Tenan
   SELECT count(*) FROM outbox_events_dlq;
   ```
   Asegura que sólo queden eventos con causa raíz abierta o aprobados para retenerse.
-- Revisa dashboards de consumidor downstream para confirmar que no hay nuevos errores asociados al lote reprocesado (por ejemplo, `broker_consumer_lag_max` estable).
+- Revisa dashboards de consumidor downstream para confirmar que no hay nuevos errores asociados al lote reprocesado (por ejemplo, panel *Lag consumidor* en `Tenant Service · Outbox & Consumers` mostrando `broker_consumer_lag_max` estable).
 - **Recuperación exitosa:** No deben generarse nuevas alertas de DLQ ni errores de reprocesamiento en los dashboards de monitoreo durante al menos 30 minutos tras la intervención.
 
 ## Rollback

--- a/docs/runbooks/tenant-consumer-lag.md
+++ b/docs/runbooks/tenant-consumer-lag.md
@@ -1,0 +1,67 @@
+# Runbook — Backlog / Latencia Tenant Service
+
+> **Dashboards**
+> - [`Tenant Service · Outbox & Consumers`](../observability/dashboards/tenant-service.json)
+> - Paneles clave: *Lag consumidor*, *Procesamiento de eventos*, *Estado de outbox*, *Eventos DLQ por tipo*
+>
+> **Alertas cubiertas:** `ConsumerBacklogHigh`, `ConsumerErrorRatioHigh`, `ConsumerLatencyP95Degraded`, `OutboxPublishingStalled`, `OutboxPendingBacklog`, `HandlerMissingEvents`, `InfraDown`
+> **Contacto:** `#oncall-plataforma`, `tenant-core@smartedify.com`, `data-platform@smartedify.com`
+
+## Preconditions
+- Alerta activa o incidente registrado.
+- Acceso a Grafana y permalinks habilitados.
+- Credenciales para `kubectl` (namespace `tenants`) y DB `tenant_service`.
+- Opcional: acceso a herramientas de tracing para correlacionar spans (`Tempo`).
+
+## Diagnóstico inicial (5 minutos)
+1. **Capturar tablero.** Filtra por `environment` y el `consumer` afectado.
+   - Guarda screenshot de *Lag consumidor* y *Procesamiento de eventos*.
+   - Exporta tabla *Eventos DLQ por tipo* (`Download CSV`) si hay entradas recientes.
+2. **Confirmar lag en PromQL.**
+   ```bash
+   kubectl -n monitoring exec deploy/prometheus -- \
+     promtool query instant http://localhost:9090 \
+     "max(broker_consumer_lag_max{consumer_group='tenant-consumer',environment='production'})"
+   ```
+3. **Verificar estado del pod.**
+   ```bash
+   kubectl get pods -n tenants -l app=tenant-consumer
+   kubectl logs deploy/tenant-consumer -n tenants --since=5m | tail -n 200
+   ```
+4. **Revisar outbox.** Ejecuta `SELECT count(*) FROM outbox_events WHERE status = 'pending';` para confirmar backlog en DB.
+
+## Mitigación
+- **Lag elevado (>10k):**
+  1. Escalar réplicas del consumidor:
+     ```bash
+     kubectl scale deploy/tenant-consumer -n tenants --replicas=<n>
+     ```
+  2. Incrementar `CONSUMER_MAX_INFLIGHT` temporalmente (parámetro Helm) si CPU < 70 %.
+  3. Verificar throughput del broker (`kafka-consumer-groups --describe`).
+- **Errores recurrentes:**
+  1. Identificar `eventType` en panel *Procesamiento de eventos*.
+  2. Buscar traza Tempo (`service.name="tenant-consumer" span.kind="server" event.type='<type>'`).
+  3. Deshabilitar handler defectuoso (`feature flag handler:<type>`) y notificar al dominio correspondiente.
+- **Outbox detenida:**
+  1. Revisar panel *Estado de outbox* y logs del publisher (`kubectl logs deploy/tenant-outbox-poller`).
+  2. Verificar credenciales broker (`SECRET_OUTBOX_BROKER`) y reintentar conexión.
+  3. Si falla, ejecutar script de failover: `./scripts/outbox/failover.sh --service tenant`.
+- **DLQ creciente:**
+  1. Seguir [`dlq-reprocessing.md`](./dlq-reprocessing.md).
+  2. Priorizar eventTypes con mayor conteo.
+
+## Validación
+- Confirmar que *Lag consumidor* < 5 000 mensajes y tendencia descendente durante 3 ventanas de 5 minutos.
+- Panel *Procesamiento de eventos* debe mostrar `status=success` dominante (>98 %).
+- `outbox_pending` estabilizado por debajo de 1 000 en panel correspondiente.
+- `kubectl get pods` sin reinicios y métricas `up{job="tenant-service"}` = 1.
+
+## Comunicación
+- Publicar resumen en `#tenant-observability` con permalinks a paneles y métricas.
+- Registrar en incidente (Jira/Notion) los valores antes/después y acciones aplicadas.
+- Actualizar `docs/status.md` si se consumió >15 % del error budget de lag.
+
+## Post-incident
+- Programar capacity review si el pico se repite (>2 veces por sprint).
+- Añadir aprendizaje en `docs/operations/daily-operations.md` (sección Tenant Service).
+- Revisar thresholds del alerting checklist e incorporar nuevas métricas si surgieron durante el incidente.

--- a/docs/status.md
+++ b/docs/status.md
@@ -45,6 +45,7 @@ Riesgos abiertos: cobertura incompleta contract tests (medio-alto), trazabilidad
 |------|--------|-------------|
 | Testing | Integración Auth estable + snapshots parciales | Formalizar pipeline `spectral lint` + snapshots sanitizados (login, refresh, forgot/reset, register) |
 | Observabilidad | Logs + métricas técnicas + tracing login | Extender tracing a tenant-context/outbox + tableros negocio |
+| Operación diaria | Bitácora manual dispersa | Consolidar rondas y cron jobs en [`docs/operations/daily-operations.md`](operations/daily-operations.md) |
 | Seguridad | Hashing + rotación refresh + JWKS dual | Automatizar rotación + revoke list access |
 | Eventos | Outbox + DLQ tenant | Emitir `user.registered` completo y consumirlo en user-service |
 | CI/CD | Workflow auth parcial | Unificar plantillas + publicar reportes métricas en summary |
@@ -113,6 +114,7 @@ Riesgos abiertos: cobertura incompleta contract tests (medio-alto), trazabilidad
 - Revisar testTimeout warnings en Jest (ajustar si persisten tras refactor config).
 - Documentar decisiones de métricas en `docs/observability/README.md` tras publicación de dashboards.
 - Registrar variables JWKS (`AUTH_JWKS_ALG`, `AUTH_JWKS_GRACE_SECONDS`, `AUTH_JWKS_ROTATION_CRON`) en el inventario de configuraciones operativas.
+- Mantener bitácora AM/PM y post-deploy siguiendo `docs/operations/daily-operations.md` (trazabilidad ejecutiva).
 
 ---
 Responsable CTO Snapshot: (auto-generado asistente) 2025-09-23


### PR DESCRIPTION
## Summary
- expand the observability guide to cover Auth and Tenant dashboards, SLOs and exported Grafana JSON
- refresh the alerting checklist and runbooks with dashboard evidence requirements and post-alert procedures per service
- add a daily operations playbook and link it from CI/CD and status documentation for executive traceability

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbdd8bb5b88329b9a166137763b544