### PR TITLE
Add Mermaid metadata lint and document diagram workflow

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Lint Mermaid metadata
+        run: npm run lint:mermaid
+
       - name: Lint shared package
         run: npm run lint --workspace @smartedify/shared
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Guía de Contribución
+
+Gracias por colaborar con SmartEdify. Esta guía resume el flujo esperado para enviar cambios y detalla el proceso específico para trabajar con los diagramas Mermaid del repositorio.
+
+## Flujo general
+1. Registra el trabajo en un issue o enlaza una entrada existente en `docs/tareas.md`.
+2. Ejecuta los linters y pruebas relevantes (`npm run lint`, `npm test`, comandos específicos por servicio) antes de abrir la PR.
+3. Actualiza la documentación relacionada (README, `docs/status.md`, `docs/spec.md`, runbooks) cuando una modificación afecte contratos, métricas o procesos operativos.
+4. Consulta `docs/README.md` para validar que el índice operativo sigue siendo coherente con tus cambios.
+
+## Diagramas Mermaid
+Sigue estos pasos siempre que crees o edites archivos en `docs/design/diagrams/`:
+
+1. Añade el bloque front matter obligatorio descrito en `docs/design/diagrams/README.md` con los campos `id`, `title`, `description`, `updated` y `tags`.
+2. Usa etiquetas HTML `<br/>` para notas o labels multilínea y evita fences ```mermaid``` en los `.mmd` (sólo debe existir la sintaxis Mermaid).
+3. Ejecuta `npm run lint:mermaid` para validar metadatos y confirmar que ningún archivo contiene fences o campos faltantes.
+4. Si el diagrama se referencia en otros documentos (por ejemplo, `README.md` o `docs/status.md`), actualízalos en la misma PR para mantener la trazabilidad.
+5. Adjunta capturas/renderizados únicamente si aportan contexto adicional; el repositorio prioriza los `.mmd` versionados y validados.
+
+Cumplir estos pasos garantiza que las automatizaciones (`scripts/lint-mermaid.mjs` y la verificación en CI) mantengan consistencia entre la documentación y los diagramas.

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ Este proyecto se distribuye bajo la licencia MIT. Consulta el archivo [LICENSE](
 1. Abre un issue o referencia una entrada en `docs/tareas.md` antes de iniciar trabajo.
 2. Sigue los linters y pruebas (`npm run lint`, `npm test`) en cada servicio modificado.
 3. Actualiza la documentación relacionada (README, spec, status) dentro de la misma PR cuando cambies contratos o métricas.
+4. Para diagramas Mermaid, sigue `docs/design/diagrams/README.md` y ejecuta `npm run lint:mermaid` antes de solicitar revisión.

--- a/docs/design/diagrams/README.md
+++ b/docs/design/diagrams/README.md
@@ -1,28 +1,82 @@
 # Catálogo de Diagramas
 
-Este directorio contiene los diagramas de arquitectura y flujos claves de SmartEdify.
+Este directorio centraliza los diagramas Mermaid de arquitectura, seguridad, observabilidad y flujos críticos de SmartEdify. Todos los archivos `.mmd` deben cumplir la convención descrita a continuación para mantener trazabilidad y automatizar validaciones.
 
-| Archivo | Título | Tipo | Propósito principal |
-|---------|--------|------|---------------------|
-| `consumer-processing-flowchart.mmd` | Consumer Processing Flowchart | Flowchart | Vista end-to-end del recorrido de un evento (outbox → broker → consumer → handler). |
-| `architecture-overview.mmd` | Architecture Overview | Flowchart | Mapa macro de componentes, dominios de responsabilidad y límites. |
-| `network-ports.mmd` | Network Ports Mapping | Flowchart | Relación host↔contenedor de puertos expuestos por servicio. |
-| `outbox-flow.mmd` | Outbox Flow | Flowchart | Detalle del pipeline de publicación desde la transacción hasta Kafka y métricas. |
-| `consumer-retry-sequence.mmd` | Consumer Retry Sequence | Sequence | Dinámica de reintentos, clasificación de errores y uso de DLQ. |
-| `tenant-context-sequence.mmd` | Tenant Context Resolution Sequence | Sequence | Resolución y cacheo de contexto de tenant + refresh de tokens. |
-| `auth-token-lifecycle.mmd` | Auth Token Lifecycle | State Diagram | Estados y transiciones del ciclo de vida de access/refresh tokens. |
-| `auth-sequence.mmd` | Auth Service Login Sequence | Sequence | Flujo de autenticación y emisión de tokens desde el gateway hasta auth-service. |
-| `jwks-rotation-sequence.mmd` | JWKS Rotation Sequence | Sequence | Flujo de publicación /well-known y rotación dual current/next. |
-| `jwks-rotation-state.mmd` | JWKS Key State Lifecycle | State Diagram | Estados: provisioning → current → retiring → deprecated → purge. |
-| `testing-architecture.mmd` | Multi-Project Testing Architecture | Flowchart | Aislamiento Jest (security / unit / integration) y teardown de recursos. |
-| `observability-roadmap.mmd` | Observability Roadmap | Gantt | Fases secuenciales de instrumentación y alertas. |
-| `auth-metrics-flow.mmd` | Auth Metrics Flow | Flowchart | Generación e incremento de métricas de negocio Auth. |
-| `security-priorities.mmd` | Security Priorities Roadmap | Flowchart | Cadena priorizada P1→P3 (JWKS, gateway, métricas, tracing, etc.). |
+## Convención de front matter
+Cada diagrama inicia con un bloque front matter en YAML (delimitado por `---`) que describe metadatos obligatorios.
 
-## Convenciones
-- Diagramas Mermaid validados (intentar mantenerlos simples para lectura en PRs).
-- Agregar `title:` en frontmatter cuando aplique.
-- Mantener nombres de archivo en `kebab-case` y contenido en inglés excepto notas contextuales.
+```yaml
+---
+id: example-diagram
+title: "SmartEdify – Example Diagram"
+description: "Resumen breve del objetivo del diagrama."
+updated: 2025-02-14
+tags: ["dominio", "tipo"]
+---
+```
+
+### Reglas por campo
+| Campo | Formato | Reglas |
+| --- | --- | --- |
+| `id` | `kebab-case` | Debe coincidir con el nombre del archivo (sin extensión) y ser único. |
+| `title` | Texto | Usar inglés y un prefijo opcional `SmartEdify –`. |
+| `description` | Texto | Describir el objetivo del diagrama en una frase. |
+| `updated` | `YYYY-MM-DD` | Fecha de última actualización relevante. |
+| `tags` | Lista | Mínimo un tag; usar palabras clave en minúsculas (ej. `architecture`, `flowchart`). |
+
+### Esquema de validación
+El bloque se valida con el siguiente esquema JSON (simplificado) y es el que verifica `scripts/lint-mermaid.mjs`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["id", "title", "description", "updated", "tags"],
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string", "pattern": "^[a-z0-9\\-]+$" },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "updated": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "tags": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}
+```
+
+## Estilo de diagramas
+- Evitar fences ```mermaid```; los archivos `.mmd` deben contener únicamente la sintaxis Mermaid.
+- Para notas o etiquetas multilínea usar `<br/>` (Mermaid interpreta saltos HTML) en lugar de `\n`.
+- Mantener comentarios escuetos (`%%`) sólo cuando agreguen contexto útil.
+- Nombres de archivo en `kebab-case`; contenido en inglés salvo anotaciones puntuales.
+
+## Catálogo actual
+| id | Archivo | Título | Tags |
+| --- | --- | --- | --- |
+| `architecture-overview` | `architecture-overview.mmd` | SmartEdify – Architecture Overview | architecture, flowchart |
+| `auth-metrics-flow` | `auth-metrics-flow.mmd` | SmartEdify – Auth Metrics Flow | auth, metrics, flowchart |
+| `auth-sequence` | `auth-sequence.mmd` | SmartEdify – Auth Service Login Sequence | auth, sequence |
+| `auth-token-lifecycle` | `auth-token-lifecycle.mmd` | SmartEdify – Auth Token Lifecycle | auth, tokens, state |
+| `consumer-processing-flowchart` | `consumer-processing-flowchart.mmd` | SmartEdify – Consumer Processing Flowchart | eventing, kafka, flowchart |
+| `consumer-retry-sequence` | `consumer-retry-sequence.mmd` | SmartEdify – Consumer Retry Sequence | eventing, reliability, sequence |
+| `jwks-rotation-sequence` | `jwks-rotation-sequence.mmd` | SmartEdify – JWKS Rotation Sequence | security, jwks, sequence |
+| `jwks-rotation-state` | `jwks-rotation-state.mmd` | SmartEdify – JWKS Key State Lifecycle | security, jwks, state |
+| `network-ports` | `network-ports.mmd` | SmartEdify – Network Ports Mapping | infrastructure, network, flowchart |
+| `observability-roadmap` | `observability-roadmap.mmd` | SmartEdify – Observability Roadmap | observability, roadmap, gantt |
+| `outbox-flow` | `outbox-flow.mmd` | SmartEdify – Outbox Flow | eventing, outbox, flowchart |
+| `security-priorities` | `security-priorities.mmd` | SmartEdify – Security Priorities Roadmap | security, roadmap, flowchart |
+| `tenant-context-sequence` | `tenant-context-sequence.mmd` | SmartEdify – Tenant Context Resolution Sequence | tenant, context, sequence |
+| `testing-architecture` | `testing-architecture.mmd` | SmartEdify – Multi-Project Testing Architecture | testing, architecture, flowchart |
+| `tracing-span-map` | `tracing-span-map.mmd` | SmartEdify – Tracing Span Map (Auth & Tenant) | observability, tracing, flowchart |
+
+## Flujo para añadir o modificar diagramas
+1. Crear/editar el archivo `.mmd` con el front matter actualizado.
+2. Seguir las reglas de estilo anteriores y documentar notas contextuales con `<br/>` cuando sean multilínea.
+3. Ejecutar `npm run lint:mermaid` (o `node scripts/lint-mermaid.mjs`) para validar metadatos y verificar que no existan fences.
+4. Adjuntar el diagrama al README raíz o a los documentos relevantes si aplica.
 
 ## Próximos Diagramas (Backlog)
 - `schema-validation-flow.mmd`: Validación de eventos (publisher + consumer) con registry.
@@ -30,5 +84,5 @@ Este directorio contiene los diagramas de arquitectura y flujos claves de SmartE
 - `contract-testing-flow.mmd`: Pipeline lint (Spectral) + snapshots + generación SDK.
 - `tracing-span-map.mmd`: Mapa de spans y atributos cross-service.
 
-## Actualización
-Si se modifica un diagrama que está referenciado en `README.md` raíz o `status.md`, verificar que las secciones siguen vigentes.
+## Actualización cruzada
+Si se modifica un diagrama referenciado en `README.md` raíz o `status.md`, validar que la información siga alineada y actualizar ambos documentos cuando corresponda.

--- a/docs/design/diagrams/architecture-overview.mmd
+++ b/docs/design/diagrams/architecture-overview.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Architecture Overview
+id: architecture-overview
+title: "SmartEdify – Architecture Overview"
+description: "High-level map of SmartEdify clients, platform services, messaging lanes, storage, and observability pillars."
+updated: 2025-02-14
+tags: ["architecture", "flowchart"]
 ---
 flowchart LR
     subgraph Client Layer

--- a/docs/design/diagrams/auth-metrics-flow.mmd
+++ b/docs/design/diagrams/auth-metrics-flow.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Auth Metrics Flow
+id: auth-metrics-flow
+title: "SmartEdify – Auth Metrics Flow"
+description: "Instrumentation path for login, refresh, and password recovery metrics across the auth lifecycle."
+updated: 2025-02-14
+tags: ["auth", "metrics", "flowchart"]
 ---
 flowchart TD
     subgraph Request[Auth Request Lifecycle]

--- a/docs/design/diagrams/auth-sequence.mmd
+++ b/docs/design/diagrams/auth-sequence.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Auth Service Login Sequence
+id: auth-sequence
+title: "SmartEdify – Auth Service Login Sequence"
+description: "Sequence diagram describing credential validation, token issuance, caching, and rotation hints for the login flow."
+updated: 2025-02-14
+tags: ["auth", "sequence"]
 ---
 sequenceDiagram
     participant C as Client

--- a/docs/design/diagrams/auth-token-lifecycle.mmd
+++ b/docs/design/diagrams/auth-token-lifecycle.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Auth Token Lifecycle
+id: auth-token-lifecycle
+title: "SmartEdify – Auth Token Lifecycle"
+description: "State transitions for access and refresh tokens, including revocation, logout, and rate limiting protections."
+updated: 2025-02-14
+tags: ["auth", "tokens", "state"]
 ---
 stateDiagram-v2
     [*] --> Unauthenticated
@@ -27,5 +31,5 @@ stateDiagram-v2
     Unauthenticated --> RateLimited: Excessive failed attempts
     RateLimited --> Unauthenticated: Cooldown elapsed
 
-    note right of Authenticated: Access Token 'short TTL'\nRefresh Token 'long TTL'\nRotation on each refresh\nStore only refresh 'httpOnly cookie'
+    note right of Authenticated: Access Token 'short TTL'<br/>Refresh Token 'long TTL'<br/>Rotation on each refresh<br/>Store only refresh 'httpOnly cookie'
 

--- a/docs/design/diagrams/consumer-processing-flowchart.mmd
+++ b/docs/design/diagrams/consumer-processing-flowchart.mmd
@@ -1,22 +1,26 @@
 ---
-title: SmartEdify - Consumer Processing Flowchart
+id: consumer-processing-flowchart
+title: "SmartEdify – Consumer Processing Flowchart"
+description: "End-to-end Kafka consumer flow from outbox polling through handler dispatch, retries, and metrics."
+updated: 2025-02-14
+tags: ["eventing", "kafka", "flowchart"]
 ---
 %% Consumer Processing Flowchart
 flowchart LR
     subgraph Outbox
-        A["DB Outbox Row\nstatus=pending"]
+        A["DB Outbox Row<br/>status=pending"]
     end
-    A -->|poll + validate| B["Publisher Abstraction\n(Logging/Kafka)"]
+    A -->|poll + validate| B["Publisher Abstraction<br/>(Logging/Kafka)"]
     B -->|produce| K[(Kafka Topic)]
     subgraph Consumers
-        K --> C1["Lag Consumer\n(lag metrics)"]
-        K --> C2["Processing Consumer\n(eachBatch)"]
+        K --> C1["Lag Consumer<br/>(lag metrics)"]
+        K --> C2["Processing Consumer<br/>(eachBatch)"]
         C2 -->|dispatch eventType| R{Registry}
         R -->|found| H1["Handler"]
         R -->|not found| NF[[handler_not_found++]]
         H1 --> M1[[processed_success++]]
         H1 --> D1[[duration_histogram]]
-        H1 -->|error| E["Classify\n(transient? permanent?)"]
+        H1 -->|error| E["Classify<br/>(transient? permanent?)"]
         E -->|transient & < max| RT["Retry backoff+jitter"]
         RT --> C2
         E -->|permanent o max| FL[[processed_error++]]

--- a/docs/design/diagrams/consumer-retry-sequence.mmd
+++ b/docs/design/diagrams/consumer-retry-sequence.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Consumer Retry Sequence
+id: consumer-retry-sequence
+title: "SmartEdify – Consumer Retry Sequence"
+description: "Kafka consumer retry orchestration covering handler outcomes, metrics, DLQ, and retry queue transitions."
+updated: 2025-02-14
+tags: ["eventing", "reliability", "sequence"]
 ---
 sequenceDiagram
     autonumber

--- a/docs/design/diagrams/jwks-rotation-sequence.mmd
+++ b/docs/design/diagrams/jwks-rotation-sequence.mmd
@@ -1,5 +1,9 @@
 ---
-title: JWKS Rotation Sequence
+id: jwks-rotation-sequence
+title: "SmartEdify – JWKS Rotation Sequence"
+description: "Detailed rotation sequence for admin jobs promoting signing keys, updating JWKS, and handling compromised keys."
+updated: 2025-02-14
+tags: ["security", "jwks", "sequence"]
 ---
 sequenceDiagram
     autonumber

--- a/docs/design/diagrams/jwks-rotation-state.mmd
+++ b/docs/design/diagrams/jwks-rotation-state.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - JWKS Key State Lifecycle
+id: jwks-rotation-state
+title: "SmartEdify – JWKS Key State Lifecycle"
+description: "State machine for provisioning, promoting, retiring, and purging signing keys exposed via JWKS."
+updated: 2025-02-14
+tags: ["security", "jwks", "state"]
 ---
 stateDiagram-v2
     [*] --> Provisioning

--- a/docs/design/diagrams/network-ports.mmd
+++ b/docs/design/diagrams/network-ports.mmd
@@ -1,9 +1,13 @@
 ---
-title: SmartEdify - Network Ports Mapping
+id: network-ports
+title: "SmartEdify – Network Ports Mapping"
+description: "Service-to-port mapping showing gateway, microservices, shared infrastructure, and observability endpoints."
+updated: 2025-02-14
+tags: ["infrastructure", "network", "flowchart"]
 ---
 flowchart TB
   subgraph Edge
-    GW[Gateway/BFF\napi.smart-edify.com:443]
+    GW[Gateway/BFF<br/>api.smart-edify.com:443]
   end
   subgraph Services[Microservicios]
     AUTH[auth-service:7001]

--- a/docs/design/diagrams/observability-roadmap.mmd
+++ b/docs/design/diagrams/observability-roadmap.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Observability Roadmap
+id: observability-roadmap
+title: "SmartEdify – Observability Roadmap"
+description: "Gantt-style plan for rolling out logging, metrics, tracing, dashboards, and analytics across services."
+updated: 2025-02-14
+tags: ["observability", "roadmap", "gantt"]
 ---
 gantt
     dateFormat  YYYY-MM-DD

--- a/docs/design/diagrams/outbox-flow.mmd
+++ b/docs/design/diagrams/outbox-flow.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Outbox Flow
+id: outbox-flow
+title: "SmartEdify – Outbox Flow"
+description: "Flowchart of the transactional outbox pipeline from domain commit to broker acknowledgement and metrics."
+updated: 2025-02-14
+tags: ["eventing", "outbox", "flowchart"]
 ---
 flowchart TD
     subgraph Domain TX

--- a/docs/design/diagrams/security-priorities.mmd
+++ b/docs/design/diagrams/security-priorities.mmd
@@ -1,14 +1,18 @@
-
-
-
+---
+id: security-priorities
+title: "SmartEdify – Security Priorities Roadmap"
+description: "Priority chain outlining security deliverables from JWKS rotation through authentication hardening."
+updated: 2025-02-14
+tags: ["security", "roadmap", "flowchart"]
+---
 flowchart LR
-    P1["Priority 1\nJWKS Rotation"]
-    P2["Priority 1\nGateway Verification"]
-    P3["Priority 1\nBusiness Metrics"]
-    P4["Priority 2\nTracing Endpoints"]
-    P5["Priority 2\nOutbox Events Auth"]
-    P6["Priority 3\nLogout + Denylist"]
-    P7["Priority 3\nWebAuthn / TOTP"]
+    P1["Priority 1<br/>JWKS Rotation"]
+    P2["Priority 1<br/>Gateway Verification"]
+    P3["Priority 1<br/>Business Metrics"]
+    P4["Priority 2<br/>Tracing Endpoints"]
+    P5["Priority 2<br/>Outbox Events Auth"]
+    P6["Priority 3<br/>Logout + Denylist"]
+    P7["Priority 3<br/>WebAuthn / TOTP"]
 
     P1 --> P2 --> P3 --> P4 --> P5 --> P6 --> P7
 

--- a/docs/design/diagrams/tenant-context-sequence.mmd
+++ b/docs/design/diagrams/tenant-context-sequence.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Tenant Context Resolution Sequence
+id: tenant-context-sequence
+title: "SmartEdify – Tenant Context Resolution Sequence"
+description: "Sequence showing how API Gateway resolves tenant context with caching, database lookups, and refresh handling."
+updated: 2025-02-14
+tags: ["tenant", "context", "sequence"]
 ---
 sequenceDiagram
     autonumber

--- a/docs/design/diagrams/testing-architecture.mmd
+++ b/docs/design/diagrams/testing-architecture.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Multi-Project Testing Architecture
+id: testing-architecture
+title: "SmartEdify – Multi-Project Testing Architecture"
+description: "Testing topology across developer workflow, Jest projects, environments, and orchestration layers."
+updated: 2025-02-14
+tags: ["testing", "architecture", "flowchart"]
 ---
 %% Testing Architecture (Multi-Project Jest)
 flowchart LR

--- a/docs/design/diagrams/tracing-span-map.mmd
+++ b/docs/design/diagrams/tracing-span-map.mmd
@@ -1,5 +1,9 @@
 ---
-title: SmartEdify - Tracing Span Map (Auth & Tenant)
+id: tracing-span-map
+title: "SmartEdify – Tracing Span Map (Auth & Tenant)"
+description: "Span inventory for key Auth and Tenant endpoints with emitted events, attributes, and correlated metrics."
+updated: 2025-02-14
+tags: ["observability", "tracing", "flowchart"]
 ---
 flowchart TD
     subgraph Auth[Auth Service]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Tooling y automatizaciones para contratos OpenAPI y utilidades transversales.",
   "scripts": {
     "lint:openapi": "npx --yes @stoplight/spectral-cli@6.11.1 lint \"api/openapi/**/*.yaml\" \"docs/**/*.yaml\"",
+    "lint:mermaid": "node scripts/lint-mermaid.mjs",
     "jwks:rotate": "npm run jwks:rotate --prefix apps/services/auth-service",
     "oidc:sync": "cp .well-known/openid-configuration.json docs/oidc/openid-configuration.json && cp .well-known/jwks.json docs/oidc/jwks.json",
     "test:all": "node scripts/run-test-suite.mjs all",

--- a/scripts/lint-mermaid.mjs
+++ b/scripts/lint-mermaid.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+import { readFile, readdir } from 'node:fs/promises';
+import { basename, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const diagramsDir = resolve(repoRoot, 'docs', 'design', 'diagrams');
+
+const requiredKeys = ['id', 'title', 'description', 'updated', 'tags'];
+
+async function collectMermaidFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectMermaidFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.mmd')) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+function parseValue(raw, context, errors) {
+  if (raw === undefined) {
+    errors.push(`${context}: missing value`);
+    return undefined;
+  }
+  const value = raw.trim();
+  if (!value.length) {
+    errors.push(`${context}: empty value`);
+    return undefined;
+  }
+
+  if (value.startsWith('[')) {
+    try {
+      return JSON.parse(value.replace(/'/g, '"'));
+    } catch (error) {
+      errors.push(`${context}: invalid array syntax (${error.message})`);
+      return undefined;
+    }
+  }
+
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      errors.push(`${context}: invalid quoted string (${error.message})`);
+      return undefined;
+    }
+  }
+
+  if (value.startsWith("'")) {
+    const inner = value.slice(1, -1);
+    return inner.replace(/\\'/g, "'");
+  }
+
+  return value;
+}
+
+function validateFrontMatter(data, relPath, expectedId, errors) {
+  for (const key of Object.keys(data)) {
+    if (!requiredKeys.includes(key)) {
+      errors.push(`${relPath}: unexpected key "${key}" in front matter`);
+    }
+  }
+
+  for (const key of requiredKeys) {
+    if (!(key in data)) {
+      errors.push(`${relPath}: missing required field "${key}"`);
+    }
+  }
+
+  if (typeof data.id !== 'string' || data.id.trim().length === 0) {
+    errors.push(`${relPath}: id must be a non-empty string`);
+  } else {
+    if (!/^[-a-z0-9]+$/.test(data.id)) {
+      errors.push(`${relPath}: id must be kebab-case (found "${data.id}")`);
+    }
+    if (data.id !== expectedId) {
+      errors.push(`${relPath}: id should match file name (${expectedId})`);
+    }
+  }
+
+  if (typeof data.title !== 'string' || data.title.trim().length === 0) {
+    errors.push(`${relPath}: title must be a non-empty string`);
+  }
+
+  if (typeof data.description !== 'string' || data.description.trim().length === 0) {
+    errors.push(`${relPath}: description must be a non-empty string`);
+  }
+
+  if (typeof data.updated !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(data.updated)) {
+    errors.push(`${relPath}: updated must use format YYYY-MM-DD`);
+  }
+
+  if (!Array.isArray(data.tags) || data.tags.length === 0) {
+    errors.push(`${relPath}: tags must be a non-empty array`);
+  } else {
+    data.tags.forEach((tag, index) => {
+      if (typeof tag !== 'string' || tag.trim().length === 0) {
+        errors.push(`${relPath}: tag at index ${index} must be a non-empty string`);
+      }
+    });
+  }
+}
+
+function extractFrontMatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    return null;
+  }
+  return match[1];
+}
+
+async function main() {
+  const errors = [];
+  let files = [];
+  try {
+    files = await collectMermaidFiles(diagramsDir);
+  } catch (error) {
+    console.error(`Error leyendo ${diagramsDir}:`, error.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const filePath of files) {
+    const relPath = relative(repoRoot, filePath);
+    let content;
+    try {
+      content = await readFile(filePath, 'utf8');
+    } catch (error) {
+      errors.push(`${relPath}: no se pudo leer el archivo (${error.message})`);
+      continue;
+    }
+
+    if (/```\s*mermaid/i.test(content)) {
+      errors.push(`${relPath}: remove \`\`\`mermaid fences (diagram files are raw Mermaid)`);
+    }
+
+    const frontMatterRaw = extractFrontMatter(content);
+    if (!frontMatterRaw) {
+      errors.push(`${relPath}: missing front matter block delimited by ---`);
+      continue;
+    }
+
+    const frontMatterLines = frontMatterRaw.split('\n');
+    const data = {};
+    for (const line of frontMatterLines) {
+      const trimmed = line.trim();
+      if (!trimmed.length) {
+        continue;
+      }
+      const match = trimmed.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+      if (!match) {
+        errors.push(`${relPath}: invalid front matter line "${line}"`);
+        continue;
+      }
+      const [, key, rawValue] = match;
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
+        errors.push(`${relPath}: duplicated key "${key}"`);
+        continue;
+      }
+      const value = parseValue(rawValue, `${relPath}: ${key}`, errors);
+      if (value !== undefined) {
+        data[key] = value;
+      }
+    }
+
+    const expectedId = basename(filePath, '.mmd');
+    validateFrontMatter(data, relPath, expectedId, errors);
+  }
+
+  if (errors.length > 0) {
+    console.error('Mermaid lint failed:');
+    for (const error of errors) {
+      console.error(` - ${error}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log('Mermaid diagrams look good.');
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected error:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document the required front matter schema for Mermaid diagrams and update the existing catalog to match the new convention
- add a lint script that validates diagram metadata/no fences and wire it into package scripts and CI
- refresh README/CONTRIBUTING guidance so contributors run the new checks when editing diagrams

## Testing
- `npm run lint:mermaid`


------
https://chatgpt.com/codex/tasks/task_e_68cbdf801c588329a3b0fe4a6ec80fc9